### PR TITLE
Restructure POMs and convert to JUnit 5

### DIFF
--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -8,15 +8,13 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
-import org.junit.Before;
-import org.junit.Test;
-import org.kiwiproject.dropwizard.consul.ConsulBundle;
-import org.kiwiproject.dropwizard.consul.ConsulConfiguration;
-import org.kiwiproject.dropwizard.consul.ConsulFactory;
 
-public class ConsulBundleTest {
+class ConsulBundleTest {
 
   private final ConsulFactory factory = spy(new ConsulFactory());
   private final Environment environment = mock(Environment.class);
@@ -30,7 +28,7 @@ public class ConsulBundleTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     bundle =
         spy(

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.util.Duration;
-import org.junit.Test;
-import org.kiwiproject.dropwizard.consul.ConsulFactory;
 
-public class ConsulFactoryTest {
+import org.junit.jupiter.api.Test;
+
+class ConsulFactoryTest {
 
   @Test
   public void testEquality() {

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -26,12 +26,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import org.junit.Before;
-import org.junit.Test;
-import org.kiwiproject.dropwizard.consul.ConsulFactory;
-import org.kiwiproject.dropwizard.consul.core.ConsulAdvertiser;
 
-public class ConsulAdvertiserTest {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.dropwizard.consul.ConsulFactory;
+
+class ConsulAdvertiserTest {
 
   public static final String SECOND_SUBNET_IP = "192.168.2.99";
   public static final String FIRST_SUBNET_IP = "192.168.1.53";
@@ -47,7 +47,7 @@ public class ConsulAdvertiserTest {
   private ConsulFactory factory;
   private String healthCheckUrl;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(consul.agentClient()).thenReturn(agent);
     when(environment.getAdminContext()).thenReturn(handler);

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListenerTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListenerTest.java
@@ -15,23 +15,22 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.kiwiproject.dropwizard.consul.core.ConsulAdvertiser;
-import org.kiwiproject.dropwizard.consul.core.ConsulServiceListener;
 
-public class ConsulServiceListenerTest {
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConsulServiceListenerTest {
 
   private final ConsulAdvertiser advertiser = mock(ConsulAdvertiser.class);
   private ScheduledExecutorService scheduler;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     scheduler = Executors.newScheduledThreadPool(1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     if (scheduler != null) {
       scheduler.shutdownNow();

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheckTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheckTest.java
@@ -10,17 +10,17 @@ import com.codahale.metrics.health.HealthCheck.Result;
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.ConsulException;
-import org.junit.Before;
-import org.junit.Test;
-import org.kiwiproject.dropwizard.consul.health.ConsulHealthCheck;
 
-public class ConsulHealthCheckTest {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConsulHealthCheckTest {
 
   private final Consul consul = mock(Consul.class);
   private final AgentClient agent = mock(AgentClient.class);
   private final ConsulHealthCheck healthCheck = new ConsulHealthCheck(consul);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(consul.agentClient()).thenReturn(agent);
   }

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManagerTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManagerTest.java
@@ -3,13 +3,13 @@ package org.kiwiproject.dropwizard.consul.managed;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.Test;
+
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
-import org.junit.Test;
 import org.kiwiproject.dropwizard.consul.core.ConsulAdvertiser;
-import org.kiwiproject.dropwizard.consul.managed.ConsulAdvertiserManager;
 
-public class ConsulAdvertiserManagerTest {
+class ConsulAdvertiserManagerTest {
 
   private final ConsulAdvertiser advertiser = mock(ConsulAdvertiser.class);
   private final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);

--- a/consul-example/pom.xml
+++ b/consul-example/pom.xml
@@ -12,13 +12,6 @@
     <artifactId>consul-example</artifactId>
     <name>Dropwizard Consul Example</name>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-        <maven.install.skip>true</maven.install.skip>
-        <maven.site.skip>true</maven.site.skip>
-        <maven.site.deploy.skip>true</maven.site.deploy.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.smoketurner.dropwizard</groupId>
-        <artifactId>dropwizard-pom</artifactId>
-        <version>2.1.4-3</version>
+        <groupId>org.kiwiproject</groupId>
+        <artifactId>kiwi-parent</artifactId>
+        <version>2.0.17</version>
     </parent>
 
     <groupId>org.kiwiproject</groupId>
@@ -15,7 +15,7 @@
 
     <name>dropwizard-consul</name>
     <description>Dropwizard Consul Bundle</description>
-    <url>https://github.com/smoketurner/dropwizard-consul</url>
+    <url>https://github.com/kiwiproject/dropwizard-consul</url>
 
     <modules>
         <module>consul-core</module>
@@ -24,24 +24,24 @@
     </modules>
 
     <scm>
-        <connection>scm:git:git://github.com/smoketurner/dropwizard-consul.git</connection>
-        <developerConnection>scm:git:git@github.com:smoketurner/dropwizard-consul.git</developerConnection>
-        <url>https://github.com/smoketurner/dropwizard-consul</url>
+        <connection>scm:git:https://github.com/kiwiproject/dropwizard-consul.git</connection>
+        <developerConnection>scm:git:git@github.com:kiwiproject/dropwizard-consul.git</developerConnection>
+        <url>https://github.com/kiwiproject/dropwizard-consul</url>
         <tag>HEAD</tag>
     </scm>
+
+    <properties>
+        <kiwi-bom.version>0.30.0</kiwi-bom.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>3.12.2</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.checkerframework</groupId>
-                <artifactId>checker-qual</artifactId>
-                <version>3.34.0</version>
+                <groupId>org.kiwiproject</groupId>
+                <artifactId>kiwi-bom</artifactId>
+                <version>${kiwi-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
* Make root POM use kiwi-parent
* Change all the various POM settings to org.kiwiproject, e.g. url, scm
* Convert tests to JUnit 5 including changing them to package-private
* Remove some unnecessary properties from consul-example POM

Closes #14
Closes #24