### PR TITLE
Clean up the EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,16 +5,14 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.properties]
-charset = latin1
+[*.{java,xml}]
+indent_size = 4
 
-[travis.yml]
+[*.yml]
 indent_size = 2
-indent_style = space
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
* Don't specify indent for all files
* Remove config for properties files
* Remove special config for Travis files b/c it's long gone
* Specify 4-space indent for Java and XML files
* Specify 2-space indent fpr Yaml files

Closes #7