### PR TITLE
Fix problems found by IntelliJ code inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,24 @@ Dependency Info
 ---------------
 
 ```xml
-<dependency>
-    <groupId>org.kiwiproject</groupId>
-    <artifactId>consul-core</artifactId>
-    <version>[current-version]</version>
-</dependency>
 
-<dependency>
-    <groupId>org.kiwiproject</groupId>
-    <artifactId>consul-ribbon</artifactId>
-    <version>[current-version]</version>
-</dependency>
+<dependencies>
+
+    <dependency>
+        <groupId>org.kiwiproject</groupId>
+        <artifactId>consul-core</artifactId>
+        <version>[current-version]</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.kiwiproject</groupId>
+        <artifactId>consul-ribbon</artifactId>
+        <version>[current-version]</version>
+    </dependency>
+
+    <!-- additional dependencies... -->
+
+</dependencies>
 ```
 
 Usage
@@ -61,15 +68,23 @@ your [Application](https://javadoc.io/doc/io.dropwizard/dropwizard-project/lates
 class.
 
 ```java
-@Override
-public void initialize(Bootstrap<MyConfiguration> bootstrap) {
-    // ...
-    bootstrap.addBundle(new ConsulBundle<MyConfiguration>(getName()) {
-        @Override
-        public ConsulFactory getConsulFactory(MyConfiguration configuration) {
-            return configuration.getConsulFactory();
-        }
-    });
+public class MyApplication extends Application<MyConfiguration> {
+
+    @Override
+    public void initialize(Bootstrap<MyConfiguration> bootstrap) {
+        // ...
+        bootstrap.addBundle(new ConsulBundle<MyConfiguration>(getName()) {
+            @Override
+            public ConsulFactory getConsulFactory(MyConfiguration configuration) {
+                return configuration.getConsulFactory();
+            }
+        });
+    }
+
+    @Override
+    public void run(MyConfiguration configuration, Environment environment) {
+        // ...
+    }
 }
 ```
 
@@ -117,8 +132,8 @@ integration points:
 
 - The application is registered as a service with Consul (with
   the [service port](https://developer.hashicorp.com/consul/docs/services/configuration/services-configuration-reference#port)
-  set to the applicationConnectors port in the configuration file.
-- The application will lookup any variables in the configuration file from Consul upon startup (it defaults to
+  set to the applicationConnectors port in the configuration file).
+- The application will look up any variables in the configuration file from Consul upon startup (it defaults to
   connecting to a Consul agent running on `localhost:8500` for this functionality)
 - The application exposes an additional HTTP endpoint for querying Consul for available healthy services:
 
@@ -187,7 +202,7 @@ Content-Length: 870
 ]
 ```
 
-- The application will periodically checkin with Consul every second to notify the service check that it is still alive
+- The application will periodically check in with Consul every second to notify the service check that it is still alive
 - Upon shutdown, the application will deregister itself from Consul
 
 Credits

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -121,7 +121,7 @@ public abstract class ConsulBundle<C extends Configuration>
     }
 
     @Override
-    public void run(C configuration, Environment environment) throws Exception {
+    public void run(C configuration, Environment environment) {
         final ConsulFactory consulConfig = getConsulFactory(configuration);
         if (!consulConfig.isEnabled()) {
             LOGGER.warn("Consul bundle disabled.");

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
@@ -54,7 +54,7 @@ public class ConsulServiceListener implements ServerLifecycleListener {
         Set<String> hosts = new HashSet<>();
 
         for (Connector connector : server.getConnectors()) {
-            @SuppressWarnings("resource") final ServerConnector serverConnector = (ServerConnector) connector;
+            final ServerConnector serverConnector = (ServerConnector) connector;
             hosts.add(serverConnector.getHost());
             if (APPLICATION_NAME.equals(connector.getName())) {
                 applicationPort = serverConnector.getLocalPort();

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheck.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheck.java
@@ -23,7 +23,7 @@ public class ConsulHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    protected Result check() {
         try {
             consul.agentClient().ping();
             return Result.healthy();

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManager.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManager.java
@@ -25,12 +25,12 @@ public class ConsulAdvertiserManager implements Managed {
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         // the advertiser is register as a Jetty startup listener
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         advertiser.deregister();
         scheduler.ifPresent(ScheduledExecutorService::shutdownNow);
     }

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/task/MaintenanceTask.java
@@ -30,7 +30,7 @@ public class MaintenanceTask extends Task {
     }
 
     @Override
-    public void execute(Map<String, List<String>> parameters, PrintWriter output) throws Exception {
+    public void execute(Map<String, List<String>> parameters, PrintWriter output) {
 
         if (!parameters.containsKey("enable")) {
             throw new IllegalArgumentException("Parameter \"enable\" not found");

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -28,7 +28,7 @@ class ConsulBundleTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
         bundle =
             spy(
                 new ConsulBundle<TestConfiguration>("test") {
@@ -42,40 +42,40 @@ class ConsulBundleTest {
     }
 
     @Test
-    void testDefaultsToEnabled() throws Exception {
+    void testDefaultsToEnabled() {
         assertThat(factory.isEnabled()).isTrue();
     }
 
     @Test
-    void testEnabled() throws Exception {
+    void testEnabled() {
         doReturn(true).when(factory).isEnabled();
         bundle.run(config, environment);
         verify(bundle, times(1)).setupEnvironment(factory, environment);
     }
 
     @Test
-    void testNotEnabled() throws Exception {
+    void testNotEnabled() {
         doReturn(false).when(factory).isEnabled();
         bundle.run(config, environment);
         verify(bundle, times(0)).setupEnvironment(factory, environment);
     }
 
     @Test
-    void testMissingServiceName() throws Exception {
+    void testMissingServiceName() {
         factory.setServiceName(null);
         bundle.run(config, environment);
         assertThat(factory.getServiceName()).isEqualTo("test");
     }
 
     @Test
-    void testPopulatedServiceName() throws Exception {
+    void testPopulatedServiceName() {
         factory.setServiceName("test-service-name");
         bundle.run(config, environment);
         assertThat(factory.getServiceName()).isEqualTo("test-service-name");
     }
 
     @Test
-    void testAclToken() throws Exception {
+    void testAclToken() {
         String token = "acl-token";
         factory.setAclToken(token);
         bundle.run(config, environment);

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -69,7 +69,7 @@ class ConsulAdvertiserTest {
     @Test
     void testRegister() {
         when(agent.isRegistered(serviceId)).thenReturn(false);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -101,7 +101,7 @@ class ConsulAdvertiserTest {
         advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
 
         when(agent.isRegistered(serviceId)).thenReturn(false);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -245,7 +245,9 @@ class ConsulAdvertiserTest {
     @Test
     void testRegisterAlreadyRegistered() {
         when(agent.isRegistered(anyString())).thenReturn(true);
-        advertiser.register("http", 8080, 8081);
+        var didRegister = register(advertiser);
+        assertThat(didRegister).isFalse();
+
         verify(agent, never())
             .register(anyInt(), anyString(), anyLong(), anyString(), anyString(), anyList(), anyMap());
     }
@@ -258,7 +260,7 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(anyString())).thenReturn(false);
         final ConsulAdvertiser advertiser =
             new ConsulAdvertiser(environment, factory, consul, serviceId);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -286,7 +288,7 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(serviceId)).thenReturn(false);
         final ConsulAdvertiser advertiser =
             new ConsulAdvertiser(environment, factory, consul, serviceId);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -314,7 +316,7 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(serviceId)).thenReturn(false);
         final ConsulAdvertiser advertiser =
             new ConsulAdvertiser(environment, factory, consul, serviceId);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -344,7 +346,7 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(serviceId)).thenReturn(false);
         final ConsulAdvertiser advertiser =
             new ConsulAdvertiser(environment, factory, consul, serviceId);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -374,7 +376,7 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(anyString())).thenReturn(false);
         final ConsulAdvertiser advertiser =
             new ConsulAdvertiser(environment, factory, consul, serviceId);
-        advertiser.register("http", 8080, 8081);
+        registerAndEnsureRegistered(advertiser);
 
         final ImmutableRegistration registration =
             ImmutableRegistration.builder()
@@ -392,6 +394,15 @@ class ConsulAdvertiserTest {
                 .build();
 
         verify(agent).register(registration);
+    }
+
+    private static void registerAndEnsureRegistered(ConsulAdvertiser advertiser) {
+        var didRegister = register(advertiser);
+        assertThat(didRegister).isTrue();
+    }
+
+    private static boolean register(ConsulAdvertiser advertiser) {
+        return advertiser.register("http", 8080, 8081);
     }
 
     @Test

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheckTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheckTest.java
@@ -25,14 +25,14 @@ class ConsulHealthCheckTest {
     }
 
     @Test
-    void testCheckHealthy() throws Exception {
+    void testCheckHealthy() {
         final Result actual = healthCheck.check();
         verify(agent).ping();
         assertThat(actual.isHealthy()).isTrue();
     }
 
     @Test
-    void testCheckUnhealthy() throws Exception {
+    void testCheckUnhealthy() {
         doThrow(new ConsulException("error")).when(agent).ping();
         final Result actual = healthCheck.check();
         verify(agent).ping();

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManagerTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManagerTest.java
@@ -17,7 +17,7 @@ class ConsulAdvertiserManagerTest {
         new ConsulAdvertiserManager(advertiser, Optional.of(scheduler));
 
     @Test
-    void testStop() throws Exception {
+    void testStop() {
         manager.stop();
         verify(advertiser).deregister();
         verify(scheduler).shutdownNow();

--- a/consul-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/consul-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -31,7 +31,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
                 bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
 
         bootstrap.addBundle(
-            new ConsulBundle<HelloWorldConfiguration>(getName(), false, true) {
+            new ConsulBundle<>(getName(), false, true) {
                 @Override
                 public ConsulFactory getConsulFactory(HelloWorldConfiguration configuration) {
                     return configuration.getConsulFactory();
@@ -40,7 +40,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
     }
 
     @Override
-    public void run(HelloWorldConfiguration configuration, Environment environment) throws Exception {
+    public void run(HelloWorldConfiguration configuration, Environment environment) {
         final Consul consul = configuration.getConsulFactory().build();
         final RibbonJerseyClient loadBalancingClient =
             new RibbonJerseyClientBuilder(environment, consul, configuration.getClient())

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
@@ -112,12 +112,12 @@ public class RibbonJerseyClientBuilder {
             .manage(
                 new Managed() {
                     @Override
-                    public void start() throws Exception {
+                    public void start() {
                         // nothing to start
                     }
 
                     @Override
-                    public void stop() throws Exception {
+                    public void stop() {
                         client.close();
                     }
                 });

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
         <version>2.0.17</version>
     </parent>
 
-    <groupId>org.kiwiproject</groupId>
     <artifactId>dropwizard-consul</artifactId>
     <version>0.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
* Remove redundant warning suppression in ConsulServiceListener
* Remove all redundant throws clauses
* Extract register call in ConsulAdvertiserTes in order to verify registration, except in the test where it is already registered
* Replace with <> in HelloWorldApplication (Java migration problems)
* Remove redundant groupId from top-level POM
* Add context in code fragments in README.md, which also ensures the code inspection on the README is happy

Closes #52