### PR TITLE
Clean up versions and dependencies in consul-ribbon and consul-example

### DIFF
--- a/consul-example/pom.xml
+++ b/consul-example/pom.xml
@@ -13,6 +13,20 @@
     <artifactId>consul-example</artifactId>
     <name>Dropwizard Consul Example</name>
 
+    <properties>
+        <rxjava.version>1.3.8</rxjava.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.reactivex</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>${rxjava.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -31,14 +45,10 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <version>1.2.0</version>
-            <scope>runtime</scope>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/consul-ribbon/pom.xml
+++ b/consul-ribbon/pom.xml
@@ -15,7 +15,18 @@
 
     <properties>
         <ribbon.version>2.7.18</ribbon.version>
+        <rxjava.version>1.3.8</rxjava.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.reactivex</groupId>
+                <artifactId>rxjava</artifactId>
+                <version>${rxjava.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -39,7 +50,6 @@
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
-            <version>1.3.8</version>
         </dependency>
         <dependency>
             <groupId>com.netflix.ribbon</groupId>


### PR DESCRIPTION
* Lock rxjava version
* Change to jakarta dependencies for jaxb-api and activation-api

Closes #37
Closes #38