### PR TITLE
First pass changing to use 'var'

### DIFF
--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -123,30 +123,29 @@ public abstract class ConsulBundle<C extends Configuration>
 
     @Override
     public void run(C configuration, Environment environment) {
-        final ConsulFactory consulConfig = getConsulFactory(configuration);
-        if (consulConfig.isEnabled()) {
-            runEnabled(consulConfig, environment);
+        var consulFactory = getConsulFactory(configuration);
+        if (consulFactory.isEnabled()) {
+            runEnabled(consulFactory, environment);
         } else {
             LOGGER.warn("Consul bundle disabled.");
         }
     }
 
-    protected void runEnabled(ConsulFactory consulConfig, Environment environment) {
-        if (isNullOrEmpty(consulConfig.getServiceName())) {
-            consulConfig.setServiceName(defaultServiceName);
+    protected void runEnabled(ConsulFactory consulFactory, Environment environment) {
+        if (isNullOrEmpty(consulFactory.getServiceName())) {
+            consulFactory.setServiceName(defaultServiceName);
         }
-        setupEnvironment(consulConfig, environment);
+        setupEnvironment(consulFactory, environment);
     }
 
-    protected void setupEnvironment(ConsulFactory consulConfig, Environment environment) {
+    protected void setupEnvironment(ConsulFactory consulFactory, Environment environment) {
 
-        final Consul consul = consulConfig.build();
-        final String serviceId = consulConfig.getServiceId().orElse(UUID.randomUUID().toString());
-        final ConsulAdvertiser advertiser =
-            new ConsulAdvertiser(environment, consulConfig, consul, serviceId);
+        var consul = consulFactory.build();
+        var serviceId = consulFactory.getServiceId().orElseGet(() -> UUID.randomUUID().toString());
+        var advertiser = new ConsulAdvertiser(environment, consulFactory, consul, serviceId);
 
-        final Optional<Duration> retryInterval = consulConfig.getRetryInterval();
-        final Optional<ScheduledExecutorService> scheduler =
+        Optional<Duration> retryInterval = consulFactory.getRetryInterval();
+        Optional<ScheduledExecutorService> scheduler =
             retryInterval.map(i -> Executors.newScheduledThreadPool(1));
 
         // Register a Jetty listener to get the listening host and port

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/config/ConsulLookup.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/config/ConsulLookup.java
@@ -54,7 +54,7 @@ public class ConsulLookup implements StringLookup {
     @Override
     public String lookup(String key) {
         try {
-            final Optional<String> value = consul.keyValueClient().getValueAsString(key);
+            Optional<String> value = consul.keyValueClient().getValueAsString(key);
             if (value.isPresent()) {
                 return value.get();
             }

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiser.java
@@ -261,7 +261,7 @@ public class ConsulAdvertiser {
      * @return Optional of the host to register as the service address or empty otherwise
      */
     private Optional<String> findFirstEligibleIpBySubnet(Collection<String> ipAddresses) {
-        SubnetUtils subnetUtils = new SubnetUtils(serviceSubnet.get());
+        var subnetUtils = new SubnetUtils(serviceSubnet.get());
         SubnetUtils.SubnetInfo subNetInfo = subnetUtils.getInfo();
         return ipAddresses.stream().filter(subNetInfo::isInRange).findFirst();
     }
@@ -297,12 +297,11 @@ public class ConsulAdvertiser {
      * @return health check URL
      */
     protected String getHealthCheckUrl(String applicationScheme, Collection<String> hosts) {
-        final UriBuilder builder = UriBuilder.fromPath(environment.getAdminContext().getContextPath());
-        builder
+        var uriBuilder = UriBuilder.fromPath(environment.getAdminContext().getContextPath())
             .path(healthCheckPath.get())
             .scheme(applicationScheme)
             .host(getServiceAddress(hosts).orElse(LOCALHOST))
             .port(serviceAdminPort.get());
-        return builder.build().toString();
+        return uriBuilder.build().toString();
     }
 }

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import com.orbitz.consul.ConsulException;
 import io.dropwizard.lifecycle.ServerLifecycleListener;
 import io.dropwizard.util.Duration;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.slf4j.Logger;
@@ -54,8 +53,8 @@ public class ConsulServiceListener implements ServerLifecycleListener {
         int adminPort = -1;
         Set<String> hosts = new HashSet<>();
 
-        for (Connector connector : server.getConnectors()) {
-            final ServerConnector serverConnector = (ServerConnector) connector;
+        for (var connector : server.getConnectors()) {
+            var serverConnector = (ServerConnector) connector;
             hosts.add(serverConnector.getHost());
             if (APPLICATION_NAME.equals(connector.getName())) {
                 applicationPort = serverConnector.getLocalPort();

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -76,7 +76,7 @@ class ConsulBundleTest {
 
     @Test
     void testAclToken() {
-        String token = "acl-token";
+        var token = "acl-token";
         factory.setAclToken(token);
         bundle.run(config, environment);
         assertThat(factory.getAclToken()).contains(token);

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
@@ -12,51 +12,51 @@ class ConsulFactoryTest {
 
     @Test
     void testEquality() {
-        final ConsulFactory actual = createFullyPopulatedConsulFactory();
-        final ConsulFactory expected = createFullyPopulatedConsulFactory();
+        ConsulFactory actual = createFullyPopulatedConsulFactory();
+        ConsulFactory expected = createFullyPopulatedConsulFactory();
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     void testCorrectlyFormattedSubnet() {
-        final ConsulFactory factory = createFullyPopulatedConsulFactory();
+        ConsulFactory factory = createFullyPopulatedConsulFactory();
         factory.setServiceSubnet("192.168.3.0/24");
         assertThat(factory.getServiceSubnet()).isPresent().contains("192.168.3.0/24");
     }
 
     @Test
     void testIncorrectlyFormattedSubnet() {
-        final ConsulFactory factory = createFullyPopulatedConsulFactory();
+        ConsulFactory factory = createFullyPopulatedConsulFactory();
         assertThatIllegalArgumentException().isThrownBy(() -> factory.setServiceSubnet("192.168.3.0/"));
     }
 
     @Test
     void testNotEqual() {
-        final ConsulFactory actual = createFullyPopulatedConsulFactory();
-        final ConsulFactory expected = createFullyPopulatedConsulFactory();
+        ConsulFactory actual = createFullyPopulatedConsulFactory();
+        ConsulFactory expected = createFullyPopulatedConsulFactory();
         expected.setAdminPort(200);
         assertThat(actual).isNotEqualTo((expected));
     }
 
     @Test
     void testHashCode() {
-        final ConsulFactory actual = createFullyPopulatedConsulFactory();
-        final ConsulFactory expected = createFullyPopulatedConsulFactory();
+        ConsulFactory actual = createFullyPopulatedConsulFactory();
+        ConsulFactory expected = createFullyPopulatedConsulFactory();
         assertThat(actual.hashCode()).hasSameHashCodeAs(expected);
     }
 
     @Test
     void testMutatedHashCode() {
-        final ConsulFactory actual = createFullyPopulatedConsulFactory();
-        final ConsulFactory expected = createFullyPopulatedConsulFactory();
+        ConsulFactory actual = createFullyPopulatedConsulFactory();
+        ConsulFactory expected = createFullyPopulatedConsulFactory();
         expected.setAdminPort(200);
         assertThat(actual.hashCode()).isNotEqualTo(expected.hashCode());
     }
 
     @Test
     void testSetServiceName() {
-        ConsulFactory consulFactory = new ConsulFactory();
-        String serviceName = "test-service";
+        var consulFactory = new ConsulFactory();
+        var serviceName = "test-service";
         consulFactory.setServiceName(serviceName);
         assertThat(consulFactory.getServiceName()).isEqualTo(serviceName);
     }
@@ -71,7 +71,7 @@ class ConsulFactoryTest {
     }
 
     private ConsulFactory createFullyPopulatedConsulFactory() {
-        final ConsulFactory consulFactory = new ConsulFactory();
+        var consulFactory = new ConsulFactory();
         consulFactory.setServiceName("serviceName");
         consulFactory.setEnabled(true);
         consulFactory.setServicePort(1000);

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.kiwiproject.dropwizard.consul.ConsulFactory;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -70,19 +69,18 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(serviceId)).thenReturn(false);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .id(serviceId)
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -102,19 +100,18 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(serviceId)).thenReturn(false);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .id(serviceId)
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -125,22 +122,20 @@ class ConsulAdvertiserTest {
         advertiser.register(
             "http", 8080, 8081, Arrays.asList(FIRST_SUBNET_IP, SECOND_SUBNET_IP, THIRD_SUBNET_IP));
 
-        String healthCheckUrlWithCorrectSubnet =
-            "http://192.168.2.99:8081/admin/" + DEFAULT_HEALTH_CHECK_PATH;
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrlWithCorrectSubnet)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .address(SECOND_SUBNET_IP)
-                .meta(Map.of("scheme", "http"))
-                .id(serviceId)
-                .build();
+        var healthCheckUrlWithCorrectSubnet = "http://192.168.2.99:8081/admin/" + DEFAULT_HEALTH_CHECK_PATH;
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrlWithCorrectSubnet)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .address(SECOND_SUBNET_IP)
+            .meta(Map.of("scheme", "http"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -151,19 +146,18 @@ class ConsulAdvertiserTest {
         advertiser.register(
             "http", 8080, 8081, Arrays.asList(FIRST_SUBNET_IP, "192.168.7.23", THIRD_SUBNET_IP));
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .id(serviceId)
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -175,21 +169,20 @@ class ConsulAdvertiserTest {
         advertiser.register(
             "http", 8080, 8081, Arrays.asList(FIRST_SUBNET_IP, "192.168.7.23", THIRD_SUBNET_IP));
 
-        String healthCheckUrlWithCorrectSubnet = "http://192.168.8.99:8081/admin/healthcheck";
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrlWithCorrectSubnet)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .address("192.168.8.99")
-                .id(serviceId)
-                .build();
+        var healthCheckUrlWithCorrectSubnet = "http://192.168.8.99:8081/admin/healthcheck";
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrlWithCorrectSubnet)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .address("192.168.8.99")
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -201,19 +194,18 @@ class ConsulAdvertiserTest {
         advertiser.register(
             "http", 8080, 8081, Arrays.asList(FIRST_SUBNET_IP, "192.168.7.23", THIRD_SUBNET_IP));
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .id(serviceId)
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -223,20 +215,19 @@ class ConsulAdvertiserTest {
         when(agent.isRegistered(serviceId)).thenReturn(false);
         advertiser.register("https", 8080, 8081);
 
-        String httpsHealthCheckUrl = "https://127.0.0.1:8081/admin/healthcheck";
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .port(8080)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(httpsHealthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "https"))
-                .id(serviceId)
-                .build();
+        var httpsHealthCheckUrl = "https://127.0.0.1:8081/admin/healthcheck";
+        var registration = ImmutableRegistration.builder()
+            .port(8080)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(httpsHealthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "https"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
@@ -257,108 +248,98 @@ class ConsulAdvertiserTest {
         factory.setServiceAddress("127.0.0.1");
 
         when(agent.isRegistered(anyString())).thenReturn(false);
-        final ConsulAdvertiser advertiser =
-            new ConsulAdvertiser(environment, factory, consul, serviceId);
+        var advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .id(serviceId)
-                .port(8888)
-                .address("127.0.0.1")
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .id(serviceId)
+            .port(8888)
+            .address("127.0.0.1")
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .build();
 
         verify(agent).register(registration);
     }
 
     @Test
     void testTagsFromConfig() {
-        final List<String> tags = Arrays.asList("test", "second-test");
+        var tags = List.of("test", "second-test");
         factory.setTags(tags);
 
         when(agent.isRegistered(serviceId)).thenReturn(false);
-        final ConsulAdvertiser advertiser =
-            new ConsulAdvertiser(environment, factory, consul, serviceId);
+        var advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .tags(tags)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .meta(Map.of("scheme", "http"))
-                .port(8080)
-                .id(serviceId)
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .tags(tags)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .meta(Map.of("scheme", "http"))
+            .port(8080)
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
 
     @Test
     void testAclTokenFromConfig() {
-        String aclToken = "acl-token";
+        var aclToken = "acl-token";
         factory.setAclToken(aclToken);
 
         when(agent.isRegistered(serviceId)).thenReturn(false);
-        final ConsulAdvertiser advertiser =
-            new ConsulAdvertiser(environment, factory, consul, serviceId);
+        var advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .id(serviceId)
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .port(8080)
-                .meta(Map.of("scheme", "http"))
-                .id(serviceId)
-                .build();
+        var registration = ImmutableRegistration.builder()
+            .id(serviceId)
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .port(8080)
+            .meta(Map.of("scheme", "http"))
+            .id(serviceId)
+            .build();
 
         verify(agent).register(registration);
     }
 
     @Test
     void testServiceMetaFromConfig() {
-        final Map<String, String> serviceMeta = new HashMap<>();
-        serviceMeta.put("meta1-key", "meta1-value");
-        serviceMeta.put("meta2-key", "meta2-value");
+        var serviceMeta = Map.of("meta1-key", "meta1-value", "meta2-key", "meta2-value");
         factory.setServiceMeta(serviceMeta);
 
         when(agent.isRegistered(serviceId)).thenReturn(false);
-        final ConsulAdvertiser advertiser =
-            new ConsulAdvertiser(environment, factory, consul, serviceId);
+        var advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .meta(serviceMeta)
-                .putMeta("scheme", "http")
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(healthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
-                .port(8080)
+        var registration = ImmutableRegistration.builder()
+            .meta(serviceMeta)
+            .putMeta("scheme", "http")
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(healthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
+            .port(8080)
                 .id(serviceId)
                 .build();
 
@@ -370,25 +351,23 @@ class ConsulAdvertiserTest {
         factory.setServicePort(8888);
         factory.setServiceAddress("127.0.0.1");
         factory.setHealthCheckPath("ping");
-        String configuredHealthCheckUrl = "http://127.0.0.1:8081/admin/ping";
+        var configuredHealthCheckUrl = "http://127.0.0.1:8081/admin/ping";
 
         when(agent.isRegistered(anyString())).thenReturn(false);
-        final ConsulAdvertiser advertiser =
-            new ConsulAdvertiser(environment, factory, consul, serviceId);
+        var advertiser = new ConsulAdvertiser(environment, factory, consul, serviceId);
         registerAndEnsureRegistered(advertiser);
 
-        final ImmutableRegistration registration =
-            ImmutableRegistration.builder()
-                .id(serviceId)
-                .port(8888)
-                .address("127.0.0.1")
-                .check(
-                    ImmutableRegCheck.builder()
-                        .http(configuredHealthCheckUrl)
-                        .interval("1s")
-                        .deregisterCriticalServiceAfter("1m")
-                        .build())
-                .name("test")
+        var registration = ImmutableRegistration.builder()
+            .id(serviceId)
+            .port(8888)
+            .address("127.0.0.1")
+            .check(
+                ImmutableRegCheck.builder()
+                    .http(configuredHealthCheckUrl)
+                    .interval("1s")
+                    .deregisterCriticalServiceAfter("1m")
+                    .build())
+            .name("test")
                 .meta(Map.of("scheme", "http"))
                 .build();
 
@@ -406,7 +385,7 @@ class ConsulAdvertiserTest {
 
     @Test
     void testDeregister() {
-        final String serviceId = advertiser.getServiceId();
+        var serviceId = advertiser.getServiceId();
         when(agent.isRegistered(serviceId)).thenReturn(true);
         advertiser.deregister();
         verify(agent).deregister(serviceId);
@@ -414,7 +393,7 @@ class ConsulAdvertiserTest {
 
     @Test
     void testDeregisterNotRegistered() {
-        final String serviceId = advertiser.getServiceId();
+        var serviceId = advertiser.getServiceId();
         when(agent.isRegistered(serviceId)).thenReturn(false);
         advertiser.deregister();
         verify(agent, never()).deregister(serviceId);

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListenerTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListenerTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -40,15 +39,14 @@ class ConsulServiceListenerTest {
 
     @Test
     void testRegister() {
-        final ConsulServiceListener listener =
-            new ConsulServiceListener(
-                advertiser, Optional.of(Duration.milliseconds(1)), Optional.of(scheduler));
+        var listener = new ConsulServiceListener(
+            advertiser, Optional.of(Duration.milliseconds(1)), Optional.of(scheduler));
 
         when(advertiser.register(any(), anyInt(), anyInt(), anyCollection()))
             .thenThrow(new ConsulException("Cannot connect to Consul"))
             .thenReturn(true);
 
-        Collection<String> hosts = Set.of("192.168.1.22");
+        var hosts = Set.of("192.168.1.22");
         listener.register("http", 0, 0, hosts);
 
         verify(advertiser, timeout(100).atLeast(1)).register("http", 0, 0, hosts);

--- a/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheckTest.java
+++ b/consul-core/src/test/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheckTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.codahale.metrics.health.HealthCheck.Result;
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.ConsulException;
@@ -26,16 +25,16 @@ class ConsulHealthCheckTest {
 
     @Test
     void testCheckHealthy() {
-        final Result actual = healthCheck.check();
+        var result = healthCheck.check();
         verify(agent).ping();
-        assertThat(actual.isHealthy()).isTrue();
+        assertThat(result.isHealthy()).isTrue();
     }
 
     @Test
     void testCheckUnhealthy() {
         doThrow(new ConsulException("error")).when(agent).ping();
-        final Result actual = healthCheck.check();
+        var result = healthCheck.check();
         verify(agent).ping();
-        assertThat(actual.isHealthy()).isFalse();
+        assertThat(result.isHealthy()).isFalse();
     }
 }

--- a/consul-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
+++ b/consul-example/src/main/java/com/example/helloworld/HelloWorldApplication.java
@@ -1,7 +1,6 @@
 package com.example.helloworld;
 
 import com.example.helloworld.resources.HelloWorldResource;
-import com.orbitz.consul.Consul;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -9,7 +8,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.kiwiproject.dropwizard.consul.ConsulBundle;
 import org.kiwiproject.dropwizard.consul.ConsulFactory;
-import org.kiwiproject.dropwizard.consul.ribbon.RibbonJerseyClient;
 import org.kiwiproject.dropwizard.consul.ribbon.RibbonJerseyClientBuilder;
 
 public class HelloWorldApplication extends Application<HelloWorldConfiguration> {
@@ -41,17 +39,15 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
 
     @Override
     public void run(HelloWorldConfiguration configuration, Environment environment) {
-        final Consul consul = configuration.getConsulFactory().build();
-        final RibbonJerseyClient loadBalancingClient =
-            new RibbonJerseyClientBuilder(environment, consul, configuration.getClient())
-                .build("hello-world");
+        var consul = configuration.getConsulFactory().build();
+        var clientConfig = configuration.getClientConfig();
+        var loadBalancingClient = new RibbonJerseyClientBuilder(environment, consul, clientConfig).build("hello-world");
 
-        final HelloWorldResource resource =
-            new HelloWorldResource(
-                consul,
-                loadBalancingClient,
-                configuration.getTemplate(),
-                configuration.getDefaultName());
+        var resource = new HelloWorldResource(
+            consul,
+            loadBalancingClient,
+            configuration.getTemplate(),
+            configuration.getDefaultName());
         environment.jersey().register(resource);
     }
 }

--- a/consul-example/src/main/java/com/example/helloworld/HelloWorldConfiguration.java
+++ b/consul-example/src/main/java/com/example/helloworld/HelloWorldConfiguration.java
@@ -21,7 +21,7 @@ public class HelloWorldConfiguration extends Configuration {
 
     @NotNull
     @Valid
-    public final RibbonJerseyClientConfiguration client = new RibbonJerseyClientConfiguration();
+    public final RibbonJerseyClientConfiguration clientConfig = new RibbonJerseyClientConfiguration();
 
     @JsonProperty
     public String getTemplate() {
@@ -49,7 +49,7 @@ public class HelloWorldConfiguration extends Configuration {
     }
 
     @JsonProperty
-    public RibbonJerseyClientConfiguration getClient() {
-        return client;
+    public RibbonJerseyClientConfiguration getClientConfig() {
+        return clientConfig;
     }
 }

--- a/consul-example/src/main/java/com/example/helloworld/resources/HelloWorldResource.java
+++ b/consul-example/src/main/java/com/example/helloworld/resources/HelloWorldResource.java
@@ -39,7 +39,7 @@ public class HelloWorldResource {
     @Timed
     @Path("/hello-world")
     public Saying sayHello(@QueryParam("name") Optional<String> name) {
-        final String value = String.format(template, name.orElse(defaultName));
+        var value = String.format(template, name.orElse(defaultName));
         return new Saying(counter.incrementAndGet(), value);
     }
 

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/ConsulServerList.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/ConsulServerList.java
@@ -7,7 +7,6 @@ import static java.util.stream.Collectors.toList;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
 import com.orbitz.consul.Consul;
-import com.orbitz.consul.model.health.Service;
 import com.orbitz.consul.model.health.ServiceHealth;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -59,9 +58,9 @@ public class ConsulServerList implements ServerList<Server> {
      * @return Ribbon Server instance
      */
     private Server buildServer(final ServiceHealth serviceHealth) {
-        Service service = serviceHealth.getService();
-        @Nullable final String scheme = service.getMeta().get("scheme");
-        final int port = service.getPort();
+        var service = serviceHealth.getService();
+        @Nullable String scheme = service.getMeta().get("scheme");
+        int port = service.getPort();
 
         final String address;
         if (isNullOrEmpty(service.getAddress())) {
@@ -70,7 +69,7 @@ public class ConsulServerList implements ServerList<Server> {
             address = service.getAddress();
         }
 
-        final Server server = new Server(scheme, address, port);
+        var server = new Server(scheme, address, port);
         server.setZone(serviceHealth.getNode().getDatacenter().orElse(Server.UNKNOWN_ZONE));
         server.setReadyToServe(true);
 

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClient.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClient.java
@@ -68,7 +68,7 @@ public class RibbonJerseyClient implements Client, Closeable {
      * @throws IllegalStateException if no servers are available
      */
     private Server fetchServerOrThrow() {
-        final Server server = loadBalancer.chooseServer();
+        var server = loadBalancer.chooseServer();
         if (isNull(server)) {
             throw new IllegalStateException("No available servers for " + loadBalancer.getName());
         }
@@ -147,12 +147,12 @@ public class RibbonJerseyClient implements Client, Closeable {
      */
     @Override
     public WebTarget target(String uri) {
-        final Server server = fetchServerOrThrow();
-        final UriBuilder builder = UriBuilder.fromUri(uri);
-        builder.scheme(server.getScheme());
-        builder.host(server.getHost());
-        builder.port(server.getPort());
-        return delegate.target(builder);
+        var server = fetchServerOrThrow();
+        var uriBuilder = UriBuilder.fromUri(uri)
+            .scheme(server.getScheme())
+            .host(server.getHost())
+            .port(server.getPort());
+        return delegate.target(uriBuilder);
     }
 
     /**
@@ -162,11 +162,11 @@ public class RibbonJerseyClient implements Client, Closeable {
      */
     @Override
     public WebTarget target(URI uri) {
-        final Server server = fetchServerOrThrow();
-        final UriBuilder builder = UriBuilder.fromUri(uri);
-        builder.scheme(server.getScheme());
-        builder.host(server.getHost());
-        builder.port(server.getPort());
+        var server = fetchServerOrThrow();
+        var builder = UriBuilder.fromUri(uri)
+            .scheme(server.getScheme())
+            .host(server.getHost())
+            .port(server.getPort());
         return delegate.target(builder);
     }
 
@@ -177,10 +177,10 @@ public class RibbonJerseyClient implements Client, Closeable {
      */
     @Override
     public WebTarget target(UriBuilder uriBuilder) {
-        final Server server = fetchServerOrThrow();
-        uriBuilder.scheme(server.getScheme());
-        uriBuilder.host(server.getHost());
-        uriBuilder.port(server.getPort());
+        var server = fetchServerOrThrow();
+        uriBuilder.scheme(server.getScheme())
+            .host(server.getHost())
+            .port(server.getPort());
         return delegate.target(uriBuilder);
     }
 
@@ -191,12 +191,12 @@ public class RibbonJerseyClient implements Client, Closeable {
      */
     @Override
     public WebTarget target(Link link) {
-        final Server server = fetchServerOrThrow();
-        final UriBuilder builder = UriBuilder.fromLink(link);
-        builder.scheme(server.getScheme());
-        builder.host(server.getHost());
-        builder.port(server.getPort());
-        return delegate.target(builder);
+        var server = fetchServerOrThrow();
+        var uriBuilder = UriBuilder.fromLink(link)
+            .scheme(server.getScheme())
+            .host(server.getHost())
+            .port(server.getPort());
+        return delegate.target(uriBuilder);
     }
 
     @Override

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
@@ -59,8 +59,7 @@ public class RibbonJerseyClientBuilder {
         final String name, final ConsulServiceDiscoverer serviceDiscoverer) {
 
         // create a new Jersey client
-        final Client jerseyClient =
-            new JerseyClientBuilder(environment).using(configuration).build(name);
+        var jerseyClient = new JerseyClientBuilder(environment).using(configuration).build(name);
 
         return build(name, jerseyClient, serviceDiscoverer);
     }
@@ -90,23 +89,23 @@ public class RibbonJerseyClientBuilder {
         final ConsulServiceDiscoverer serviceDiscoverer) {
 
         // dynamic server list that is refreshed from Consul
-        final ConsulServerList serverList = new ConsulServerList(consul, serviceDiscoverer);
+        var serverList = new ConsulServerList(consul, serviceDiscoverer);
 
         // build a new load balancer based on the configuration
-        final DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
+        var clientConfig = new DefaultClientConfigImpl();
         clientConfig.set(CommonClientConfigKey.AppName, name);
         clientConfig.set(
             CommonClientConfigKey.ServerListRefreshInterval,
             Ints.checkedCast(configuration.getRefreshInterval().toMilliseconds()));
 
-        final ZoneAwareLoadBalancer<Server> loadBalancer =
+        ZoneAwareLoadBalancer<Server> loadBalancer =
             LoadBalancerBuilder.newBuilder()
                 .withClientConfig(clientConfig)
                 .withRule(new WeightedResponseTimeRule())
                 .withDynamicServerList(serverList)
                 .buildDynamicServerListLoadBalancer();
 
-        final RibbonJerseyClient client = new RibbonJerseyClient(loadBalancer, jerseyClient);
+        var client = new RibbonJerseyClient(loadBalancer, jerseyClient);
 
         environment
             .lifecycle()


### PR DESCRIPTION
* Change local variables to use 'var' to tidy things up and make local variable declarations less noisy and redundant
* Remove (some) final modifiers from local variable declarations. There are still a lot more on variables, parameters, etc. that can be cleaned up as they are noisy and (except for fields) don't really add that much value. And yes, I am well aware that Effective Java says to use final everywhere, and I disagree for the reasons that it makes the code less readable and very noisy, without adding much (if any) value in modern JVMs.

Part of #44