### PR TITLE
Remove final modifier from parameters

### DIFF
--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -52,7 +52,7 @@ public abstract class ConsulBundle<C extends Configuration>
      * @param name Service Name
      */
     @SuppressWarnings("java:S5993")
-    public ConsulBundle(final String name) {
+    public ConsulBundle(String name) {
         this(name, false);
     }
 
@@ -61,7 +61,7 @@ public abstract class ConsulBundle<C extends Configuration>
      * @param strict If true, the application fails fast if a key cannot be found in Consul KV
      */
     @SuppressWarnings("java:S5993")
-    public ConsulBundle(final String name, final boolean strict) {
+    public ConsulBundle(String name, boolean strict) {
         this(name, strict, false);
     }
 
@@ -71,8 +71,7 @@ public abstract class ConsulBundle<C extends Configuration>
      * @param substitutionInVariables If true, substitution will be done within variable names.
      */
     @SuppressWarnings("java:S5993")
-    public ConsulBundle(
-        final String name, final boolean strict, final boolean substitutionInVariables) {
+    public ConsulBundle(String name, boolean strict, boolean substitutionInVariables) {
         this.defaultServiceName = requireNonNull(name);
         this.strict = strict;
         this.substitutionInVariables = substitutionInVariables;
@@ -86,8 +85,7 @@ public abstract class ConsulBundle<C extends Configuration>
         try {
             LOGGER.debug("Connecting to Consul at {}:{}", getConsulAgentHost(), getConsulAgentPort());
 
-            final Consul.Builder builder =
-                Consul.builder()
+            var consulBuilder = Consul.builder()
                     .withHostAndPort(HostAndPort.fromParts(getConsulAgentHost(), getConsulAgentPort()));
 
             getConsulAclToken()
@@ -101,7 +99,7 @@ public abstract class ConsulBundle<C extends Configuration>
 
                         LOGGER.debug("Using Consul ACL token: {}", token);
 
-                        builder
+                        consulBuilder
                             .withAclToken(token)
                             .withHeaders(Map.of(CONSUL_AUTH_HEADER_KEY, token));
                     });
@@ -110,7 +108,7 @@ public abstract class ConsulBundle<C extends Configuration>
             bootstrap.setConfigurationSourceProvider(
                 new SubstitutingSourceProvider(
                     bootstrap.getConfigurationSourceProvider(),
-                    new ConsulSubstitutor(builder.build(), strict, substitutionInVariables)));
+                    new ConsulSubstitutor(consulBuilder.build(), strict, substitutionInVariables)));
 
         } catch (ConsulException e) {
             LOGGER.warn(

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
@@ -233,7 +233,7 @@ public class ConsulFactory {
     @JsonIgnore
     public Consul build() {
 
-        final Consul.Builder builder = Consul.builder().withHostAndPort(endpoint).withPing(servicePing);
+        var consulBuilder = Consul.builder().withHostAndPort(endpoint).withPing(servicePing);
 
         // setting both acl token here and with header, supplying an auth
         // header. This should cover both use cases: endpoint supports
@@ -241,9 +241,9 @@ public class ConsulFactory {
         // requires an X-Consul-Token header.
         // @see https://www.consul.io/api/index.html#acls
         aclToken.ifPresent(token ->
-            builder.withAclToken(token).withHeaders(Map.of(CONSUL_AUTH_HEADER_KEY, token)));
+            consulBuilder.withAclToken(token).withHeaders(Map.of(CONSUL_AUTH_HEADER_KEY, token)));
 
-        return builder.build();
+        return consulBuilder.build();
     }
 
     @Override
@@ -272,7 +272,7 @@ public class ConsulFactory {
         if (isNull(obj) || getClass() != obj.getClass()) {
             return false;
         }
-        final ConsulFactory other = (ConsulFactory) obj;
+        var other = (ConsulFactory) obj;
         return Objects.equals(this.endpoint, other.endpoint)
             && Objects.equals(this.serviceName, other.serviceName)
             && Objects.equals(this.enabled, other.enabled)

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/config/ConsulLookup.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/config/ConsulLookup.java
@@ -26,7 +26,7 @@ public class ConsulLookup implements StringLookup {
      *
      * @param consul Consul client
      */
-    public ConsulLookup(final Consul consul) {
+    public ConsulLookup(Consul consul) {
         this(consul, true);
     }
 
@@ -39,7 +39,7 @@ public class ConsulLookup implements StringLookup {
      * @throws UndefinedEnvironmentVariableException if the environment variable doesn't exist and
      *                                               strict behavior is enabled.
      */
-    public ConsulLookup(final Consul consul, final boolean strict) {
+    public ConsulLookup(Consul consul, boolean strict) {
         this.consul = requireNonNull(consul);
         this.strict = strict;
     }

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/config/ConsulSubstitutor.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/config/ConsulSubstitutor.java
@@ -9,11 +9,11 @@ import io.dropwizard.configuration.UndefinedEnvironmentVariableException;
  */
 public class ConsulSubstitutor extends EnvironmentVariableSubstitutor {
 
-    public ConsulSubstitutor(final Consul consul) {
+    public ConsulSubstitutor(Consul consul) {
         this(consul, true, false);
     }
 
-    public ConsulSubstitutor(final Consul consul, boolean strict) {
+    public ConsulSubstitutor(Consul consul, boolean strict) {
         this(consul, strict, false);
     }
 
@@ -26,7 +26,7 @@ public class ConsulSubstitutor extends EnvironmentVariableSubstitutor {
      * @param substitutionInVariables a flag whether substitution is done in variable names.
      * @see org.apache.commons.text.StringSubstitutor#setEnableSubstitutionInVariables(boolean)
      */
-    public ConsulSubstitutor(final Consul consul, boolean strict, boolean substitutionInVariables) {
+    public ConsulSubstitutor(Consul consul, boolean strict, boolean substitutionInVariables) {
         super(strict);
         this.setVariableResolver(new ConsulLookup(consul, strict));
         this.setEnableSubstitutionInVariables(substitutionInVariables);

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
@@ -35,10 +35,9 @@ public class ConsulServiceListener implements ServerLifecycleListener {
      * @param retryInterval When specified, will retry if service registration fails
      * @param scheduler     When specified, will retry if service registration fails
      */
-    public ConsulServiceListener(
-        final ConsulAdvertiser advertiser,
-        final Optional<Duration> retryInterval,
-        final Optional<ScheduledExecutorService> scheduler) {
+    public ConsulServiceListener(ConsulAdvertiser advertiser,
+                                 Optional<Duration> retryInterval,
+                                 Optional<ScheduledExecutorService> scheduler) {
 
         this.advertiser = requireNonNull(advertiser, "advertiser == null");
         this.retryInterval = requireNonNull(retryInterval, "retryInterval == null");
@@ -46,8 +45,7 @@ public class ConsulServiceListener implements ServerLifecycleListener {
     }
 
     @Override
-    public void serverStarted(final Server server) {
-
+    public void serverStarted(Server server) {
         String applicationScheme = null;
         int applicationPort = -1;
         int adminPort = -1;
@@ -98,8 +96,7 @@ public class ConsulServiceListener implements ServerLifecycleListener {
      * @param adminPort         Administration listening port
      * @param hosts             List of addresses the service is bound to.
      */
-    void register(
-        String applicationScheme, int applicationPort, int adminPort, Collection<String> hosts) {
+    void register(String applicationScheme, int applicationPort, int adminPort, Collection<String> hosts) {
         try {
             advertiser.register(applicationScheme, applicationPort, adminPort, hosts);
             scheduler.ifPresent(ScheduledExecutorService::shutdownNow);

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheck.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/health/ConsulHealthCheck.java
@@ -18,7 +18,7 @@ public class ConsulHealthCheck extends HealthCheck {
      *
      * @param consul Consul client
      */
-    public ConsulHealthCheck(final Consul consul) {
+    public ConsulHealthCheck(Consul consul) {
         this.consul = requireNonNull(consul);
     }
 

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManager.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManager.java
@@ -20,8 +20,7 @@ public class ConsulAdvertiserManager implements Managed {
      * @param advertiser Consul advertiser
      * @param scheduler  Optional retry scheduler
      */
-    public ConsulAdvertiserManager(
-        final ConsulAdvertiser advertiser, final Optional<ScheduledExecutorService> scheduler) {
+    public ConsulAdvertiserManager(ConsulAdvertiser advertiser, Optional<ScheduledExecutorService> scheduler) {
         this.advertiser = requireNonNull(advertiser, "advertiser == null");
         this.scheduler = requireNonNull(scheduler, "scheduler == null");
     }

--- a/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/task/MaintenanceTask.java
+++ b/consul-core/src/main/java/org/kiwiproject/dropwizard/consul/task/MaintenanceTask.java
@@ -25,7 +25,7 @@ public class MaintenanceTask extends Task {
      * @param consul    Consul client
      * @param serviceId Service ID to toggle maintenance mode
      */
-    public MaintenanceTask(final Consul consul, final String serviceId) {
+    public MaintenanceTask(Consul consul, String serviceId) {
         super("maintenance");
         this.consul = requireNonNull(consul);
         this.serviceId = requireNonNull(serviceId);
@@ -38,14 +38,14 @@ public class MaintenanceTask extends Task {
             throw new IllegalArgumentException("Parameter \"enable\" not found");
         }
 
-        final boolean enable = Boolean.parseBoolean(parameters.get("enable").get(0));
-        final String reason;
+        String reason;
         if (parameters.containsKey("reason")) {
             reason = Strings.nullToEmpty(parameters.get("reason").get(0));
         } else {
             reason = "";
         }
 
+        var enable = Boolean.parseBoolean(parameters.get("enable").get(0));
         if (enable) {
             if (isNullOrEmpty(reason)) {
                 LOGGER.warn("Enabling maintenance mode for service {} (no reason given)", serviceId);

--- a/consul-example/src/main/java/com/example/helloworld/resources/HelloWorldResource.java
+++ b/consul-example/src/main/java/com/example/helloworld/resources/HelloWorldResource.java
@@ -26,8 +26,7 @@ public class HelloWorldResource {
     private final String defaultName;
     private final AtomicLong counter;
 
-    public HelloWorldResource(
-        Consul consul, RibbonJerseyClient client, String template, String defaultName) {
+    public HelloWorldResource(Consul consul, RibbonJerseyClient client, String template, String defaultName) {
         this.consul = consul;
         this.client = client;
         this.template = template;

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/ConsulServerList.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/ConsulServerList.java
@@ -24,7 +24,7 @@ public class ConsulServerList implements ServerList<Server> {
      * @param consul            Consul client
      * @param serviceDiscoverer Discoverer
      */
-    public ConsulServerList(final Consul consul, final ConsulServiceDiscoverer serviceDiscoverer) {
+    public ConsulServerList(Consul consul, ConsulServiceDiscoverer serviceDiscoverer) {
         this.consul = requireNonNull(consul);
         this.serviceDiscoverer = requireNonNull(serviceDiscoverer);
     }
@@ -45,7 +45,7 @@ public class ConsulServerList implements ServerList<Server> {
      * @param services list of healthy service instances
      * @return list of server instances
      */
-    private List<Server> buildServerList(final Collection<ServiceHealth> services) {
+    private List<Server> buildServerList(Collection<ServiceHealth> services) {
         return services.stream().map(this::buildServer).collect(toList());
     }
 
@@ -57,12 +57,12 @@ public class ConsulServerList implements ServerList<Server> {
      * @param serviceHealth Consul service health record
      * @return Ribbon Server instance
      */
-    private Server buildServer(final ServiceHealth serviceHealth) {
+    private Server buildServer(ServiceHealth serviceHealth) {
         var service = serviceHealth.getService();
         @Nullable String scheme = service.getMeta().get("scheme");
         int port = service.getPort();
 
-        final String address;
+        String address;
         if (isNullOrEmpty(service.getAddress())) {
             address = serviceHealth.getNode().getAddress();
         } else {

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/HealthyConsulServiceDiscoverer.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/HealthyConsulServiceDiscoverer.java
@@ -16,12 +16,12 @@ public class HealthyConsulServiceDiscoverer implements ConsulServiceDiscoverer {
      *
      * @param service Service name
      */
-    public HealthyConsulServiceDiscoverer(final String service) {
+    public HealthyConsulServiceDiscoverer(String service) {
         this.service = requireNonNull(service);
     }
 
     @Override
-    public Collection<ServiceHealth> discover(final Consul consul) {
+    public Collection<ServiceHealth> discover(Consul consul) {
         return consul.healthClient().getHealthyServiceInstances(service).getResponse();
     }
 }

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClient.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClient.java
@@ -29,8 +29,7 @@ public class RibbonJerseyClient implements Client, Closeable {
      * @param loadBalancer Load Balancer
      * @param delegate     Jersey Client delegate
      */
-    public RibbonJerseyClient(
-        final ZoneAwareLoadBalancer<Server> loadBalancer, final Client delegate) {
+    public RibbonJerseyClient(ZoneAwareLoadBalancer<Server> loadBalancer, Client delegate) {
         this.loadBalancer = requireNonNull(loadBalancer);
         this.delegate = requireNonNull(delegate);
     }
@@ -44,10 +43,9 @@ public class RibbonJerseyClient implements Client, Closeable {
      * @deprecated Use non-scheme constructor instead
      */
     @Deprecated(since = "0.5.0", forRemoval = true)
-    public RibbonJerseyClient(
-        @SuppressWarnings("unused") final String scheme,
-        final ZoneAwareLoadBalancer<Server> loadBalancer,
-        final Client delegate) {
+    public RibbonJerseyClient(@SuppressWarnings("unused") String scheme,
+                              ZoneAwareLoadBalancer<Server> loadBalancer,
+                              Client delegate) {
         this.loadBalancer = requireNonNull(loadBalancer);
         this.delegate = requireNonNull(delegate);
     }

--- a/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
+++ b/consul-ribbon/src/main/java/org/kiwiproject/dropwizard/consul/ribbon/RibbonJerseyClientBuilder.java
@@ -29,10 +29,9 @@ public class RibbonJerseyClientBuilder {
      * @param consul        Consul client
      * @param configuration Load balancer Configuration
      */
-    public RibbonJerseyClientBuilder(
-        final Environment environment,
-        final Consul consul,
-        final RibbonJerseyClientConfiguration configuration) {
+    public RibbonJerseyClientBuilder(Environment environment,
+                                     Consul consul,
+                                     RibbonJerseyClientConfiguration configuration) {
         this.environment = requireNonNull(environment);
         this.consul = requireNonNull(consul);
         this.configuration = requireNonNull(configuration);
@@ -44,7 +43,7 @@ public class RibbonJerseyClientBuilder {
      * @param name Service name
      * @return new RibbonJerseyClient
      */
-    public RibbonJerseyClient build(final String name) {
+    public RibbonJerseyClient build(String name) {
         return build(name, new HealthyConsulServiceDiscoverer(name));
     }
 
@@ -55,8 +54,7 @@ public class RibbonJerseyClientBuilder {
      * @param serviceDiscoverer Service discoverer
      * @return new RibbonJerseyClient
      */
-    public RibbonJerseyClient build(
-        final String name, final ConsulServiceDiscoverer serviceDiscoverer) {
+    public RibbonJerseyClient build(String name, ConsulServiceDiscoverer serviceDiscoverer) {
 
         // create a new Jersey client
         var jerseyClient = new JerseyClientBuilder(environment).using(configuration).build(name);
@@ -71,7 +69,7 @@ public class RibbonJerseyClientBuilder {
      * @param jerseyClient Jersey Client
      * @return new {@link RibbonJerseyClient}
      */
-    public RibbonJerseyClient build(final String name, final Client jerseyClient) {
+    public RibbonJerseyClient build(String name, Client jerseyClient) {
         return build(name, jerseyClient, new HealthyConsulServiceDiscoverer(name));
     }
 
@@ -83,10 +81,7 @@ public class RibbonJerseyClientBuilder {
      * @param serviceDiscoverer Service discoverer
      * @return new RibbonJerseyClient
      */
-    public RibbonJerseyClient build(
-        final String name,
-        final Client jerseyClient,
-        final ConsulServiceDiscoverer serviceDiscoverer) {
+    public RibbonJerseyClient build(String name, Client jerseyClient, ConsulServiceDiscoverer serviceDiscoverer) {
 
         // dynamic server list that is refreshed from Consul
         var serverList = new ConsulServerList(consul, serviceDiscoverer);


### PR DESCRIPTION
* Remove final modifier from method and ctor arguments since it is noisy and really doesn't add much value
* Reformat methods and constructors so the args are on one line or lined up "correctly" (where that is the way we like them)
* Replace a few more explicit types with 'var' and rename the variable when it makes sense, e.g. consulBuilder instead of builder

Part of #44