### PR TITLE
Add build, Sonar, CodeQL, and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 Dropwizard Consul Bundle
 ========================
 
+[![build](https://github.com/kiwiproject/dropwizard-consul/actions/workflows/build.yml/badge.svg)](https://github.com/kiwiproject/dropwizard-consul/actions/workflows/build.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kiwiproject_dropwizard-consul&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kiwiproject_dropwizard-consul)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kiwiproject_dropwizard-consul&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kiwiproject_dropwizard-consul)
+[![CodeQL](https://github.com/kiwiproject/dropwizard-consul/actions/workflows/codeql.yml/badge.svg)](https://github.com/kiwiproject/dropwizard-consul/actions/workflows/codeql.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 _This README is a work in progress as we transition dropwizard-consul from smoketurner to kiwiproject._
 
 Introduction


### PR DESCRIPTION
Add initial set of badges. Can't add javadoc and Maven Central yet.

Part of #22