### PR TITLE
Log exception at DEBUG during initialization; provide status methods

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -1,16 +1,20 @@
 package org.kiwiproject.dropwizard.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ConsulBundleTest {
@@ -39,6 +43,31 @@ class ConsulBundleTest {
                 });
 
         doNothing().when(bundle).setupEnvironment(factory, environment);
+    }
+
+    @Nested
+    class Initialize {
+
+        @Test
+        void shouldReportWhenInitializationHasNotYetOccurred() {
+            assertThat(bundle.didAttemptInitialize()).isFalse();
+        }
+
+        @Test
+        void shouldReportInitializationSuccessAsFalse_WhenInitializationHasNotBeenAttemptedYet() {
+            assertThat(bundle.didInitializeSucceed()).isFalse();
+        }
+
+        @Test
+        void shouldNotAllowConsulExceptionToEscape_WhenUnableToConnecttoConsul() {
+            var bootstrap = mock(Bootstrap.class);
+            assertThatCode(() -> bundle.initialize(bootstrap)).doesNotThrowAnyException();
+
+            assertThat(bundle.didAttemptInitialize()).isTrue();
+            assertThat(bundle.didInitializeSucceed()).isFalse();
+
+            verifyNoInteractions(bootstrap);  // should throw before trying to set up the ConfigurationSourceProvider
+        }
     }
 
     @Test


### PR DESCRIPTION
* Log the fact that the bundle could not contact Consul during initialization at WARN level, but without including the stack trace of the ConsulException. Include text stating that configuration substitution cannot be performed. Also include text stating that the stack trace can be viewed by enabling DEBUG level
* Log the ConsulException stack trace at DEBUG level
* Add ability to query the ConsulBundle whether intialization has been attempted and whether it succeeded.
* Extracted some local variables from repeated method calls
* Extracted a local var for the Consul object built from the factory before trying to set the ConfigurationSourceProvider; this permits the test to verify no method was called on Bootstrap in addition to making the code a little clearer, i.e. building the Consul instance is not buried in several levels of method calls.

Closes  #60