### PR TITLE
Fix ConsulBundleTest so it works when a Consul agent is running

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
         <!-- Test dependencies -->
 
         <dependency>
+            <groupId>org.kiwiproject</groupId>
+            <artifactId>kiwi</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -18,6 +18,7 @@ import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.net.LocalPortChecker;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -66,6 +67,8 @@ class ConsulBundleTest {
         @Test
         void shouldNotAllowConsulExceptionToEscape_WhenUnableToConnecttoConsul() {
             var bootstrap = mock(Bootstrap.class);
+            var openPort = new LocalPortChecker().findRandomOpenPort().orElseThrow();
+            doReturn(openPort).when(bundle).getConsulAgentPort();
             assertThatCode(() -> bundle.initialize(bootstrap)).doesNotThrowAnyException();
 
             assertThat(bundle.didAttemptInitialize()).isTrue();


### PR DESCRIPTION
Choose a random open port and mock the ConsulBundle#getConsulAgentPort so that it returns that open port. This guarantees that even if there is a Consul agent running locally (on any port), this test will pass because it is trying to connect to an open port.

Added kiwi as a *test* dependency to use its LocalPortChecker. If we refactor this library to use kiwi in production code, then the dependency will need to be changed to remove the test scope.

Fixes #100