### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: ['11', '17', '20']
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.0</version>
     </parent>
 
     <artifactId>dropwizard-consul</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -30,8 +30,8 @@
     <properties>
         <!-- Versions for required dependencies -->
         <commons-net.version>3.9.0</commons-net.version>
-        <consul-client.version>0.9.0</consul-client.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <consul-client.version>1.0.0</consul-client.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- Versions for test dependencies -->
         <test-containers.version>1.18.3</test-containers.version>

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -5,11 +5,11 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
-import io.dropwizard.Configuration;
-import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.ConfiguredBundle;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.util.Duration;
 import org.kiwiproject.consul.Consul;
 import org.kiwiproject.consul.ConsulException;

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulConfiguration.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulConfiguration.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.dropwizard.consul;
 
-import io.dropwizard.Configuration;
+import io.dropwizard.core.Configuration;
 
 @FunctionalInterface
 public interface ConsulConfiguration<C extends Configuration> {

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
@@ -8,12 +8,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.net.HostAndPort;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.net.util.SubnetUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kiwiproject.consul.Consul;
 import org.kiwiproject.consul.config.ClientConfig;
 
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -102,7 +102,7 @@ public class ConsulFactory {
     public void setServiceName(@Nullable String serviceName) {
         this.serviceName = serviceName;
     }
-    
+
     @JsonProperty
     public Optional<Iterable<String>> getTags() {
         return tags;

--- a/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiser.java
@@ -3,7 +3,8 @@ package org.kiwiproject.dropwizard.consul.core;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.setup.Environment;
+import jakarta.ws.rs.core.UriBuilder;
 import org.apache.commons.net.util.SubnetUtils;
 import org.kiwiproject.consul.Consul;
 import org.kiwiproject.consul.ConsulException;
@@ -13,7 +14,6 @@ import org.kiwiproject.dropwizard.consul.ConsulFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.UriBuilder;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleIntegrationTest.java
@@ -5,11 +5,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.dropwizard.Configuration;
 import io.dropwizard.configuration.ConfigurationSourceProvider;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Bootstrap;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.dropwizard.consul.config.ConsulSubstitutor;

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -10,9 +10,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import io.dropwizard.Configuration;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+import io.dropwizard.core.Configuration;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -125,7 +125,7 @@ class ConsulBundleTest {
         assertThat(factory.getNetworkWriteTimeoutMillis()).contains(5_000L);
         assertThat(factory.getNetworkReadTimeoutMillis()).contains(10_005L);
         assertThat(factory.getClientConfig()).hasValueSatisfying(theClientConfig ->
-                assertThat(theClientConfig.getCacheConfig().getWatchDuration().toSeconds()).isEqualTo(20L));
+            assertThat(theClientConfig.getCacheConfig().getWatchDuration().toSeconds()).isEqualTo(20L));
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiserTest.java
@@ -12,8 +12,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jetty.MutableServletContextHandler;
-import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.consul.AgentClient;


### PR DESCRIPTION
* Bump version to 1.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.0
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9