### PR TITLE
Add two new constructors in ConsulAdvertiserManager and deprecate one

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -170,7 +170,7 @@ public abstract class ConsulBundle<C extends Configuration>
         environment.healthChecks().register("consul", new ConsulHealthCheck(consul));
 
         // Register a shutdown manager to deregister the service
-        environment.lifecycle().manage(new ConsulAdvertiserManager(advertiser, scheduler));
+        environment.lifecycle().manage(new ConsulAdvertiserManager(advertiser, scheduler.orElse(null)));
 
         // Add an administrative task to toggle maintenance mode
         environment.admin().addTask(new MaintenanceTask(consul, serviceId));

--- a/src/main/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManager.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManager.java
@@ -1,37 +1,76 @@
 package org.kiwiproject.dropwizard.consul.managed;
 
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import io.dropwizard.lifecycle.Managed;
+import org.jspecify.annotations.Nullable;
 import org.kiwiproject.dropwizard.consul.core.ConsulAdvertiser;
 
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
+/**
+ * Dropwizard {@link Managed} component that coordinates the lifecycle of a {@link ConsulAdvertiser}.
+ */
 public class ConsulAdvertiserManager implements Managed {
 
     private final ConsulAdvertiser advertiser;
-    private final Optional<ScheduledExecutorService> scheduler;
+    private final ScheduledExecutorService scheduler;
 
     /**
-     * Constructor
+     * Create a new instance.
+     *
+     * @param advertiser   Consul advertiser
+     * @param schedulerOpt Optional retry scheduler; may not be null
+     * @deprecated use {@link #ConsulAdvertiserManager(ConsulAdvertiser, ScheduledExecutorService)}
+     */
+    @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S1133", "DeprecatedIsStillUsed" })
+    @Deprecated(since = "1.3.0", forRemoval = true)
+    public ConsulAdvertiserManager(ConsulAdvertiser advertiser, Optional<ScheduledExecutorService> schedulerOpt) {
+        this.advertiser = requireNonNull(advertiser, "advertiser == null");
+        this.scheduler = requireNonNull(schedulerOpt, "scheduler == null").orElse(null);
+    }
+
+    /**
+     * Create a new instance with no scheduler. Only use this if you aren't using a retry scheduler.
      *
      * @param advertiser Consul advertiser
-     * @param scheduler  Optional retry scheduler
      */
-    public ConsulAdvertiserManager(ConsulAdvertiser advertiser, Optional<ScheduledExecutorService> scheduler) {
-        this.advertiser = requireNonNull(advertiser, "advertiser == null");
-        this.scheduler = requireNonNull(scheduler, "scheduler == null");
+    public ConsulAdvertiserManager(ConsulAdvertiser advertiser) {
+        this(advertiser, (ScheduledExecutorService) null);
     }
 
+    /**
+     * Create a new instance.
+     *
+     * @param advertiser Consul advertiser
+     * @param scheduler  Retry scheduler; may be null
+     */
+    public ConsulAdvertiserManager(ConsulAdvertiser advertiser, @Nullable ScheduledExecutorService scheduler) {
+        this.advertiser = requireNonNull(advertiser, "advertiser must not be null");
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * No-op startup hook.
+     * <p>
+     * The associated {@link ConsulAdvertiser} is expected to be registered as a Jetty startup listener and
+     * perform its own initialization when the server starts.
+     */
     @Override
     public void start() {
-        // the advertiser is register as a Jetty startup listener
+        // the advertiser is registered as a Jetty startup listener
     }
 
+    /**
+     * Deregisters the service from Consul and shuts down the retry scheduler if this instance contains one.
+     */
     @Override
     public void stop() {
         advertiser.deregister();
-        scheduler.ifPresent(ScheduledExecutorService::shutdownNow);
+        if (nonNull(scheduler)) {
+            scheduler.shutdownNow();
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManagerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/managed/ConsulAdvertiserManagerTest.java
@@ -1,25 +1,78 @@
 package org.kiwiproject.dropwizard.consul.managed;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.dropwizard.consul.core.ConsulAdvertiser;
 
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
+@DisplayName("ConsulAdvertiserManager")
 class ConsulAdvertiserManagerTest {
 
-    private final ConsulAdvertiser advertiser = mock(ConsulAdvertiser.class);
-    private final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-    private final ConsulAdvertiserManager manager =
-        new ConsulAdvertiserManager(advertiser, Optional.of(scheduler));
+    private ConsulAdvertiser advertiser;
+    private ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() {
+        advertiser = mock(ConsulAdvertiser.class);
+        scheduler = mock(ScheduledExecutorService.class);
+    }
+
+    // Yes, this "test" is a bit silly. It's a "just in case" test.
+    @Test
+    void shouldAllowStartCallsButDoNothing() {
+        var manager = new ConsulAdvertiserManager(advertiser, scheduler);
+
+        manager.start();
+        manager.start();
+        manager.start();
+
+        verifyNoInteractions(advertiser, scheduler);
+    }
+
+    @SuppressWarnings("removal")
+    @Test
+    void shouldDeregisterAdvertiserAndShutdownScheduler_WhenConstructedUsingDeprecatedConstructor() {
+        var manager = new ConsulAdvertiserManager(advertiser, Optional.of(scheduler));
+
+        manager.stop();
+
+        verify(advertiser, only()).deregister();
+        verify(scheduler, only()).shutdownNow();
+    }
 
     @Test
-    void testStop() {
+    void shouldDeregisterAdvertiserAndShutdownScheduler_WhenSchedulerNotNull() {
+        var manager = new ConsulAdvertiserManager(advertiser, scheduler);
+
         manager.stop();
-        verify(advertiser).deregister();
-        verify(scheduler).shutdownNow();
+
+        verify(advertiser, only()).deregister();
+        verify(scheduler, only()).shutdownNow();
+    }
+
+    @Test
+    void shouldDeregisterAdvertiserAndIgnoreScheduler_WhenConstrucedWithoutAScheduler() {
+        var manager = new ConsulAdvertiserManager(advertiser);
+
+        manager.stop();
+
+        verify(advertiser, only()).deregister();
+    }
+
+    @Test
+    void shouldDeregisterAdvertiserAndIgnoreScheduler_WhenSchedulerIsNull() {
+        var manager = new ConsulAdvertiserManager(advertiser, (ScheduledExecutorService) null);
+
+        manager.stop();
+
+        verify(advertiser, only()).deregister();
     }
 }


### PR DESCRIPTION
* Deprecate the constructor that accepts Optional (for removal).
* Add constructor that accepts a (nullable) ScheduledExecutorService as the retry scheduler.
* Add constructor with only one argument; delegates to the other new constructor passing null as the ScheduledExecutorService.
* Change scheduler field to be a (nullable) ScheduledExecutorService.
* Add some Javadocs.

Closes #237
Closes #238
Closes #239
Closes #240