### PR TITLE
Add dependencies that are used but were undeclared

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,51 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!--
+                TODO: Remove this once on a dropwizard-logging version that uses 1.5.3 (or higher)
+
+                Prior to 1.5.3, this included its own org.jspecify.annotations.Nullable annotation
+                in its own source code, for some strange reason. Version 1.5.3 shaded it. See:
+                https://github.com/dropwizard/logback-throttling-appender/releases/tag/logback-throttling-appender-1.5.3
+            -->
+            <dependency>
+                <groupId>io.dropwizard.logback</groupId>
+                <artifactId>logback-throttling-appender</artifactId>
+                <version>1.5.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-lifecycle</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-servlets</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-validation</artifactId>
         </dependency>
 
         <dependency>
@@ -66,13 +104,53 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-healthchecks</artifactId>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
Add dependencies that are used directly in our code, i.e., reported by the Maven Dependency Analyzer. Mostly corresponds to things we have import statements for.

Additions:

* commons-lang3
* commons-text
* dropwizard-configuration
* dropwizard-lifecycle
* dropwizard-servlets
* dropwizard-util
* dropwizard-validation
* guava
* jackson-annotations
* jakarta.ws.rs-api
* jakarta.validation-api
* jetty-server
* metrics-healthchecks

Also had to manage the version of logback-throttling-appender because version 1.5.1 (used by Dropwizard 4.x) has its own copy of the JSpecify Nullable annotation, for some strange and probably not good reason. Version 1.5.3 shades it, so the real JSpecify one is correctly resolved.