### PR TITLE
Log invalid or no retry interval in ConsulServiceListener#register

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListener.java
@@ -209,6 +209,9 @@ public class ConsulServiceListener implements ServerLifecycleListener {
                     TimeUnit.MILLISECONDS
                 );
             } else if (hasScheduler()) {
+                LOG.info("Will not try to register service with ID {} again." +
+                        " Ensure there is a valid retryInterval if you want retry behavior. (retryInterval: {})",
+                    serviceId, retryInterval);
                 scheduler.shutdownNow();
             }
         }


### PR DESCRIPTION
If we fail to register with Consul and RetryResult#shouldRetry returned false, but there is a scheduler, log the fact that we won't try to register again. Mention a possible remedy is to check that a retryInterval exists and is valid.