### PR TITLE
Clean up mock verifications in ConsulServiceListenerTest

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListenerTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/core/ConsulServiceListenerTest.java
@@ -11,9 +11,9 @@ import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.dropwizard.util.Duration;
@@ -85,7 +85,7 @@ class ConsulServiceListenerTest {
 
             listener.serverStarted(server);
 
-            verify(advertiser, never()).register(anyString(), anyInt(), anyInt(), anyCollection());
+            verifyNoInteractions(advertiser);
         }
 
         @Test
@@ -95,7 +95,7 @@ class ConsulServiceListenerTest {
 
             listener.serverStarted(server);
 
-            verify(advertiser, never()).register(anyString(), anyInt(), anyInt(), anyCollection());
+            verifyNoInteractions(advertiser);
         }
 
         @Test
@@ -107,7 +107,7 @@ class ConsulServiceListenerTest {
 
             listener.serverStarted(server);
 
-            verify(advertiser, never()).register(anyString(), anyInt(), anyInt(), anyCollection());
+            verifyNoInteractions(advertiser);
         }
 
         @Test
@@ -119,7 +119,7 @@ class ConsulServiceListenerTest {
 
             listener.serverStarted(server);
 
-            verify(advertiser, never()).register(anyString(), anyInt(), anyInt(), anyCollection());
+            verifyNoInteractions(advertiser);
         }
 
         @Test


### PR DESCRIPTION
Instead of verifying that  the ConsulAdvertiser#register method is never called using the never() VerificationMode, we can be more generic and verify that there were no interactions at all with ConsulAdvertiser.