### PR TITLE
Fix value in registration metadata for adminScheme

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiser.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/core/ConsulAdvertiser.java
@@ -290,7 +290,7 @@ public class ConsulAdvertiser {
 
         registrationBuilder.putMeta("scheme", applicationScheme);
         registrationBuilder.putMeta("applicationScheme", applicationScheme);
-        registrationBuilder.putMeta("adminScheme", applicationScheme);
+        registrationBuilder.putMeta("adminScheme", adminScheme);
 
         agentClient.register(registrationBuilder.build());
         return true;


### PR DESCRIPTION
* Add tests to check registering with different schemes and ports.
* Fix ConsulAdvertiser#register which was incorrectly setting the adminScheme in the registration metadata with  the application scheme.

Relates to #269