### PR TITLE
Add Unix domain socket support for Consul agent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ configure the bundle to use it via `config.yml`:
 
 ```yaml
 consul:
-  socketPath: /var/run/consul/consul.sock
+  unixDomainSocketPath: /var/run/consul/consul.sock
 ```
 
-When `socketPath` is set, the `endpoint` must be left at its default
-(`localhost:8500`); configuring both `socketPath` and a non-default `endpoint`
-at the same time is an error.
+When `unixDomainSocketPath` is set, the `endpoint` must be left at its default
+(`localhost:8500`); configuring both `unixDomainSocketPath` and a non-default
+`endpoint` at the same time is an error.
 
 ### Dependency
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,66 @@ consul:
   checkInterval: 1 second
 ```
 
+Unix Domain Socket Support
+--------------------------
+
+If your Consul agent is configured to listen on a Unix domain socket, you can
+configure the bundle to use it via `config.yml`:
+
+```yaml
+consul:
+  socketPath: /var/run/consul/consul.sock
+```
+
+When `socketPath` is set, the `endpoint` must be left at its default
+(`localhost:8500`); configuring both `socketPath` and a non-default `endpoint`
+at the same time is an error.
+
+### Dependency
+
+Unix domain socket support depends on `junixsocket-core`, which is an
+**optional** dependency and must be added explicitly if you want to use this
+feature.
+
+If you are using [kiwi-bom](https://github.com/kiwiproject/kiwi-bom) **3.1.0
+or later** for dependency management, the version is managed for you:
+
+```xml
+<dependency>
+    <groupId>com.kohlschutter.junixsocket</groupId>
+    <artifactId>junixsocket-core</artifactId>
+    <type>pom</type>
+</dependency>
+```
+
+Otherwise, specify the version explicitly (see
+[Maven Central](https://central.sonatype.com/artifact/com.kohlschutter.junixsocket/junixsocket-core)
+for the latest version):
+
+```xml
+<dependency>
+    <groupId>com.kohlschutter.junixsocket</groupId>
+    <artifactId>junixsocket-core</artifactId>
+    <version>[latest-version]</version>
+    <type>pom</type>
+</dependency>
+```
+
+### JVM Requirements
+
+On Java 24+, you must explicitly enable native access for junixsocket at JVM
+startup. The correct flag depends on whether your application is modularized:
+
+**Non-modularized applications** (fat JARs, most Dropwizard/Spring Boot apps):
+```
+--enable-native-access=ALL-UNNAMED
+```
+
+**Modularized applications:**
+```
+--enable-native-access=org.newsclub.net.unix
+```
+
 Migrating from smoketurner/dropwizard-consul
 --------------------------------------------
 To migrate an existing project from [smoketurner/dropwizard-consul](https://github.com/smoketurner/dropwizard-consul), you need

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.kohlschutter.junixsocket</groupId>
+            <artifactId>junixsocket-core</artifactId>
+            <type>pom</type>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -89,14 +89,20 @@ public abstract class ConsulBundle<C extends Configuration>
 
         // Replace variables with values from Consul KV. Please override
         // getConsulAgentHost() and getConsulAgentPort() if Consul is not
-        // listening on the default localhost:8500.
+        // listening on the default localhost:8500. Or override
+        // getConsulAgentSocketPath() to connect via a Unix domain socket.
+        var socketPath = getConsulAgentSocketPath();
         var consulAgentHost = getConsulAgentHost();
         var consulAgentPort = getConsulAgentPort();
         try {
-            LOG.debug("Connecting to Consul at {}:{}", consulAgentHost, consulAgentPort);
-
-            var consulBuilder = Consul.builder()
-                    .withHostAndPort(HostAndPort.fromParts(consulAgentHost, consulAgentPort));
+            var consulBuilder = Consul.builder();
+            if (socketPath.isPresent()) {
+                LOG.debug("Connecting to Consul via Unix domain socket at {}", socketPath.get());
+                consulBuilder.withUnixDomainSocket(socketPath.get());
+            } else {
+                LOG.debug("Connecting to Consul at {}:{}", consulAgentHost, consulAgentPort);
+                consulBuilder.withHostAndPort(HostAndPort.fromParts(consulAgentHost, consulAgentPort));
+            }
 
             getConsulAclToken()
                 .ifPresent(
@@ -125,11 +131,18 @@ public abstract class ConsulBundle<C extends Configuration>
             initializeSucceeded.set(true);
         } catch (ConsulException e) {
             initializeSucceeded.set(false);
-            LOG.warn(
-                "Unable to query Consul at {}:{}, so cannot perform configuration substitution from Consul KV (enable DEBUG to see stack trace)",
-                consulAgentHost,
-                consulAgentPort);
-            LOG.debug("Stack trace for failure to connect to Consul at {}:{}", consulAgentHost, consulAgentPort, e);
+            if (socketPath.isPresent()) {
+                LOG.warn(
+                    "Unable to query Consul via Unix domain socket at {}, so cannot perform configuration substitution from Consul KV (enable DEBUG to see stack trace)",
+                    socketPath.get());
+                LOG.debug("Stack trace for failure to connect to Consul via Unix domain socket at {}", socketPath.get(), e);
+            } else {
+                LOG.warn(
+                    "Unable to query Consul at {}:{}, so cannot perform configuration substitution from Consul KV (enable DEBUG to see stack trace)",
+                    consulAgentHost,
+                    consulAgentPort);
+                LOG.debug("Stack trace for failure to connect to Consul at {}:{}", consulAgentHost, consulAgentPort, e);
+            }
         }
     }
 
@@ -184,24 +197,33 @@ public abstract class ConsulBundle<C extends Configuration>
 
     /**
      * Override as necessary to provide an alternative Consul Agent Host. This is only required if
-     * using Consul KV for configuration variable substitution.
+     * using Consul KV for configuration variable substitution and not using a Unix domain socket.
      *
      * @return By default, "localhost"
      */
-    @VisibleForTesting
     public String getConsulAgentHost() {
         return Consul.DEFAULT_HTTP_HOST;
     }
 
     /**
      * Override as necessary to provide an alternative Consul Agent Port. This is only required if
-     * using Consul KV for configuration variable substitution.
+     * using Consul KV for configuration variable substitution and not using a Unix domain socket.
      *
      * @return By default, 8500
      */
-    @VisibleForTesting
     public int getConsulAgentPort() {
         return Consul.DEFAULT_HTTP_PORT;
+    }
+
+    /**
+     * Override as necessary to connect to the local Consul agent via a Unix domain socket.
+     * When present, the socket path takes precedence over the host and port. This is only
+     * required if using Consul KV for configuration variable substitution via a Unix domain socket.
+     *
+     * @return By default, empty (no Unix domain socket)
+     */
+    public Optional<String> getConsulAgentSocketPath() {
+        return Optional.empty();
     }
 
     /**
@@ -210,7 +232,6 @@ public abstract class ConsulBundle<C extends Configuration>
      *
      * @return By default, empty string (no ACL support)
      */
-    @VisibleForTesting
     public Optional<String> getConsulAclToken() {
         return Optional.empty();
     }

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulBundle.java
@@ -90,15 +90,15 @@ public abstract class ConsulBundle<C extends Configuration>
         // Replace variables with values from Consul KV. Please override
         // getConsulAgentHost() and getConsulAgentPort() if Consul is not
         // listening on the default localhost:8500. Or override
-        // getConsulAgentSocketPath() to connect via a Unix domain socket.
-        var socketPath = getConsulAgentSocketPath();
+        // getConsulAgentUnixDomainSocketPath() to connect via a Unix domain socket.
+        var unixDomainSocketPath = getConsulAgentUnixDomainSocketPath();
         var consulAgentHost = getConsulAgentHost();
         var consulAgentPort = getConsulAgentPort();
         try {
             var consulBuilder = Consul.builder();
-            if (socketPath.isPresent()) {
-                LOG.debug("Connecting to Consul via Unix domain socket at {}", socketPath.get());
-                consulBuilder.withUnixDomainSocket(socketPath.get());
+            if (unixDomainSocketPath.isPresent()) {
+                LOG.debug("Connecting to Consul via Unix domain socket at {}", unixDomainSocketPath.get());
+                consulBuilder.withUnixDomainSocket(unixDomainSocketPath.get());
             } else {
                 LOG.debug("Connecting to Consul at {}:{}", consulAgentHost, consulAgentPort);
                 consulBuilder.withHostAndPort(HostAndPort.fromParts(consulAgentHost, consulAgentPort));
@@ -131,11 +131,11 @@ public abstract class ConsulBundle<C extends Configuration>
             initializeSucceeded.set(true);
         } catch (ConsulException e) {
             initializeSucceeded.set(false);
-            if (socketPath.isPresent()) {
+            if (unixDomainSocketPath.isPresent()) {
                 LOG.warn(
                     "Unable to query Consul via Unix domain socket at {}, so cannot perform configuration substitution from Consul KV (enable DEBUG to see stack trace)",
-                    socketPath.get());
-                LOG.debug("Stack trace for failure to connect to Consul via Unix domain socket at {}", socketPath.get(), e);
+                    unixDomainSocketPath.get());
+                LOG.debug("Stack trace for failure to connect to Consul via Unix domain socket at {}", unixDomainSocketPath.get(), e);
             } else {
                 LOG.warn(
                     "Unable to query Consul at {}:{}, so cannot perform configuration substitution from Consul KV (enable DEBUG to see stack trace)",
@@ -222,7 +222,7 @@ public abstract class ConsulBundle<C extends Configuration>
      *
      * @return By default, empty (no Unix domain socket)
      */
-    public Optional<String> getConsulAgentSocketPath() {
+    public Optional<String> getConsulAgentUnixDomainSocketPath() {
         return Optional.empty();
     }
 

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.net.HostAndPort;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import org.apache.commons.net.util.SubnetUtils;
 import org.jspecify.annotations.Nullable;
@@ -56,7 +57,7 @@ public class ConsulFactory {
     private Long networkWriteTimeoutMillis;
     private Long networkReadTimeoutMillis;
     private ClientConfig clientConfig;
-    private String socketPath;
+    private String unixDomainSocketPath;
 
     @JsonProperty
     public boolean isEnabled() {
@@ -264,26 +265,31 @@ public class ConsulFactory {
 
     @Nullable
     @JsonProperty
-    public String getSocketPath() {
-        return socketPath;
+    public String getUnixDomainSocketPath() {
+        return unixDomainSocketPath;
     }
 
     @JsonProperty
-    public void setSocketPath(@Nullable String socketPath) {
-        this.socketPath = socketPath;
+    public void setUnixDomainSocketPath(@Nullable String unixDomainSocketPath) {
+        this.unixDomainSocketPath = unixDomainSocketPath;
+    }
+
+    @AssertTrue(message = "unixDomainSocketPath and a non-default endpoint cannot both be configured; use one or the other")
+    @JsonIgnore
+    @SuppressWarnings("unused")
+    public boolean isUnixDomainSocketPathOrEndpointValid() {
+        if (unixDomainSocketPath == null) {
+            return true;
+        }
+        var defaultEndpoint = HostAndPort.fromParts(Consul.DEFAULT_HTTP_HOST, Consul.DEFAULT_HTTP_PORT);
+        return endpoint.equals(defaultEndpoint);
     }
 
     @JsonIgnore
     public Consul build() {
-        var defaultEndpoint = HostAndPort.fromParts(Consul.DEFAULT_HTTP_HOST, Consul.DEFAULT_HTTP_PORT);
-        if (socketPath != null && !endpoint.equals(defaultEndpoint)) {
-            throw new IllegalStateException(
-                "Cannot configure both socketPath and a non-default endpoint; use one or the other");
-        }
-
         var consulBuilder = Consul.builder().withPing(servicePing);
-        if (socketPath != null) {
-            consulBuilder.withUnixDomainSocket(socketPath);
+        if (unixDomainSocketPath != null) {
+            consulBuilder.withUnixDomainSocket(unixDomainSocketPath);
         } else {
             consulBuilder.withHostAndPort(endpoint);
         }
@@ -319,7 +325,7 @@ public class ConsulFactory {
             aclToken,
             serviceMeta,
             servicePing,
-            socketPath);
+            unixDomainSocketPath);
     }
 
     @Override
@@ -344,7 +350,7 @@ public class ConsulFactory {
             && Objects.equals(this.aclToken, other.aclToken)
             && Objects.equals(this.serviceMeta, other.serviceMeta)
             && Objects.equals(this.servicePing, other.servicePing)
-            && Objects.equals(this.socketPath, other.socketPath);
+            && Objects.equals(this.unixDomainSocketPath, other.unixDomainSocketPath);
     }
 
     private static boolean isValidCidrIp(String cidrIp) {

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
@@ -56,6 +56,7 @@ public class ConsulFactory {
     private Long networkWriteTimeoutMillis;
     private Long networkReadTimeoutMillis;
     private ClientConfig clientConfig;
+    private String socketPath;
 
     @JsonProperty
     public boolean isEnabled() {
@@ -261,10 +262,31 @@ public class ConsulFactory {
         this.clientConfig = clientConfig;
     }
 
+    @Nullable
+    @JsonProperty
+    public String getSocketPath() {
+        return socketPath;
+    }
+
+    @JsonProperty
+    public void setSocketPath(@Nullable String socketPath) {
+        this.socketPath = socketPath;
+    }
+
     @JsonIgnore
     public Consul build() {
+        var defaultEndpoint = HostAndPort.fromParts(Consul.DEFAULT_HTTP_HOST, Consul.DEFAULT_HTTP_PORT);
+        if (socketPath != null && !endpoint.equals(defaultEndpoint)) {
+            throw new IllegalStateException(
+                "Cannot configure both socketPath and a non-default endpoint; use one or the other");
+        }
 
-        var consulBuilder = Consul.builder().withHostAndPort(endpoint).withPing(servicePing);
+        var consulBuilder = Consul.builder().withPing(servicePing);
+        if (socketPath != null) {
+            consulBuilder.withUnixDomainSocket(socketPath);
+        } else {
+            consulBuilder.withHostAndPort(endpoint);
+        }
 
         // Setting the acl token here and a header, supplying an auth
         // header. This should cover both use cases: endpoint supports
@@ -296,7 +318,8 @@ public class ConsulFactory {
             deregisterInterval,
             aclToken,
             serviceMeta,
-            servicePing);
+            servicePing,
+            socketPath);
     }
 
     @Override
@@ -320,7 +343,8 @@ public class ConsulFactory {
             && Objects.equals(this.deregisterInterval, other.deregisterInterval)
             && Objects.equals(this.aclToken, other.aclToken)
             && Objects.equals(this.serviceMeta, other.serviceMeta)
-            && Objects.equals(this.servicePing, other.servicePing);
+            && Objects.equals(this.servicePing, other.servicePing)
+            && Objects.equals(this.socketPath, other.socketPath);
     }
 
     private static boolean isValidCidrIp(String cidrIp) {

--- a/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
+++ b/src/main/java/org/kiwiproject/dropwizard/consul/ConsulFactory.java
@@ -274,6 +274,13 @@ public class ConsulFactory {
         this.unixDomainSocketPath = unixDomainSocketPath;
     }
 
+    @AssertTrue(message = "unixDomainSocketPath must not be blank when provided")
+    @JsonIgnore
+    @SuppressWarnings("unused")
+    public boolean isUnixDomainSocketPathNotBlank() {
+        return unixDomainSocketPath == null || !unixDomainSocketPath.isBlank();
+    }
+
     @AssertTrue(message = "unixDomainSocketPath and a non-default endpoint cannot both be configured; use one or the other")
     @JsonIgnore
     @SuppressWarnings("unused")

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -28,6 +28,7 @@ import org.kiwiproject.net.LocalPortChecker;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 class ConsulBundleTest {
 
@@ -112,6 +113,43 @@ class ConsulBundleTest {
             verify(bundle).buildConsulClient(any());
             verifyNoInteractions(bootstrap);
         }
+
+        @Test
+        void shouldNotAllowConsulExceptionToEscape_IfConsulExceptionThrown_ViaSocketPath() {
+            var bootstrap = mock(Bootstrap.class);
+
+            doReturn(Optional.of("/tmp/consul.sock")).when(bundle).getConsulAgentSocketPath();
+            doThrow(new ConsulException("unexpected error")).when(bundle).buildConsulClient(any());
+
+            assertThatCode(() -> bundle.initialize(bootstrap)).doesNotThrowAnyException();
+
+            assertThat(bundle.didAttemptInitialize()).isTrue();
+            assertThat(bundle.didInitializeSucceed()).isFalse();
+
+            verify(bundle).buildConsulClient(any());
+            verifyNoInteractions(bootstrap);
+        }
+
+        @Test
+        void shouldInitializeViaSocketPath_WhenSocketPathIsPresent() {
+            var bootstrap = mock(Bootstrap.class);
+            when(bootstrap.getConfigurationSourceProvider()).thenReturn(mock(ConfigurationSourceProvider.class));
+
+            doReturn(Optional.of("/tmp/consul.sock")).when(bundle).getConsulAgentSocketPath();
+            assertThatCode(() -> bundle.initialize(bootstrap)).doesNotThrowAnyException();
+
+            assertThat(bundle.didAttemptInitialize()).isTrue();
+            assertThat(bundle.didInitializeSucceed()).isTrue();
+
+            verify(bootstrap).getConfigurationSourceProvider();
+            verify(bootstrap).setConfigurationSourceProvider(any());
+            verifyNoMoreInteractions(bootstrap);
+        }
+    }
+
+    @Test
+    void shouldReturnEmptySocketPath_ByDefault() {
+        assertThat(bundle.getConsulAgentSocketPath()).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulBundleTest.java
@@ -118,7 +118,7 @@ class ConsulBundleTest {
         void shouldNotAllowConsulExceptionToEscape_IfConsulExceptionThrown_ViaSocketPath() {
             var bootstrap = mock(Bootstrap.class);
 
-            doReturn(Optional.of("/tmp/consul.sock")).when(bundle).getConsulAgentSocketPath();
+            doReturn(Optional.of("/tmp/consul.sock")).when(bundle).getConsulAgentUnixDomainSocketPath();
             doThrow(new ConsulException("unexpected error")).when(bundle).buildConsulClient(any());
 
             assertThatCode(() -> bundle.initialize(bootstrap)).doesNotThrowAnyException();
@@ -135,7 +135,7 @@ class ConsulBundleTest {
             var bootstrap = mock(Bootstrap.class);
             when(bootstrap.getConfigurationSourceProvider()).thenReturn(mock(ConfigurationSourceProvider.class));
 
-            doReturn(Optional.of("/tmp/consul.sock")).when(bundle).getConsulAgentSocketPath();
+            doReturn(Optional.of("/tmp/consul.sock")).when(bundle).getConsulAgentUnixDomainSocketPath();
             assertThatCode(() -> bundle.initialize(bootstrap)).doesNotThrowAnyException();
 
             assertThat(bundle.didAttemptInitialize()).isTrue();
@@ -148,8 +148,8 @@ class ConsulBundleTest {
     }
 
     @Test
-    void shouldReturnEmptySocketPath_ByDefault() {
-        assertThat(bundle.getConsulAgentSocketPath()).isEmpty();
+    void shouldReturnEmptyUnixDomainSocketPath_ByDefault() {
+        assertThat(bundle.getConsulAgentUnixDomainSocketPath()).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.dropwizard.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.dropwizard.util.Duration;
@@ -139,6 +140,56 @@ class ConsulFactoryTest {
 
         var consul = consulFactory.build();
         assertThat(consul).isNotNull();
+    }
+
+    @Test
+    void shouldHaveNullSocketPathByDefault() {
+        var consulFactory = new ConsulFactory();
+        assertThat(consulFactory.getSocketPath()).isNull();
+    }
+
+    @Test
+    void shouldSetSocketPath() {
+        var consulFactory = new ConsulFactory();
+        consulFactory.setSocketPath("/tmp/consul.sock");
+        assertThat(consulFactory.getSocketPath()).isEqualTo("/tmp/consul.sock");
+    }
+
+    @Test
+    void shouldBuildConsulInstanceViaSocketPath() {
+        var consulFactory = new ConsulFactory();
+        consulFactory.setServicePing(false);
+        consulFactory.setSocketPath("/tmp/consul.sock");
+
+        var consul = consulFactory.build();
+        assertThat(consul).isNotNull();
+    }
+
+    @Test
+    void shouldThrowIllegalStateException_WhenBothSocketPathAndNonDefaultEndpointConfigured() {
+        var consulFactory = new ConsulFactory();
+        consulFactory.setSocketPath("/tmp/consul.sock");
+        consulFactory.setEndpoint(com.google.common.net.HostAndPort.fromParts("consul.example.com", 8500));
+
+        assertThatIllegalStateException().isThrownBy(consulFactory::build)
+            .withMessageContaining("socketPath")
+            .withMessageContaining("endpoint");
+    }
+
+    @Test
+    void socketPath_ShouldAffectEquality() {
+        var factory1 = createFullyPopulatedConsulFactory();
+        var factory2 = createFullyPopulatedConsulFactory();
+        factory2.setSocketPath("/tmp/consul.sock");
+        assertThat(factory1).isNotEqualTo(factory2);
+    }
+
+    @Test
+    void socketPath_ShouldAffectHashCode() {
+        var factory1 = createFullyPopulatedConsulFactory();
+        var factory2 = createFullyPopulatedConsulFactory();
+        factory2.setSocketPath("/tmp/consul.sock");
+        assertThat(factory1.hashCode()).isNotEqualTo(factory2.hashCode());
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
@@ -2,9 +2,9 @@ package org.kiwiproject.dropwizard.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.google.common.net.HostAndPort;
 import io.dropwizard.util.Duration;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.consul.Consul;
 
 import java.util.List;
 
@@ -134,61 +135,62 @@ class ConsulFactoryTest {
     }
 
     @Test
-    void shouldBuildConsulInstance() {
+    void shouldHaveNullUnixDomainSocketPathByDefault() {
         var consulFactory = new ConsulFactory();
-        consulFactory.setServicePing(false);
-
-        var consul = consulFactory.build();
-        assertThat(consul).isNotNull();
+        assertThat(consulFactory.getUnixDomainSocketPath()).isNull();
     }
 
     @Test
-    void shouldHaveNullSocketPathByDefault() {
+    void shouldSetUnixDomainSocketPath() {
         var consulFactory = new ConsulFactory();
-        assertThat(consulFactory.getSocketPath()).isNull();
+        consulFactory.setUnixDomainSocketPath("/tmp/consul.sock");
+        assertThat(consulFactory.getUnixDomainSocketPath()).isEqualTo("/tmp/consul.sock");
+    }
+
+    @Nested
+    class ConnectionMode {
+
+        @Test
+        void shouldUseHostAndPort_WhenUnixDomainSocketPathIsNotSet() {
+            var factory = new ConsulFactory();
+            factory.setServicePing(false);
+
+            // No socket path configured: host/port mode is active, UDS is not
+            assertThat(factory.getUnixDomainSocketPath()).isNull();
+            assertThat(factory.getEndpoint())
+                .isEqualTo(HostAndPort.fromParts(Consul.DEFAULT_HTTP_HOST, Consul.DEFAULT_HTTP_PORT));
+
+            assertThat(factory.build()).isNotNull();
+        }
+
+        @Test
+        void shouldUseUnixDomainSocket_WhenUnixDomainSocketPathIsSet() {
+            var factory = new ConsulFactory();
+            factory.setServicePing(false);
+            factory.setUnixDomainSocketPath("/tmp/consul.sock");
+
+            // Socket path is set and endpoint is at its default: UDS mode is active, TCP is not
+            assertThat(factory.getUnixDomainSocketPath()).isEqualTo("/tmp/consul.sock");
+            assertThat(factory.getEndpoint())
+                .isEqualTo(HostAndPort.fromParts(Consul.DEFAULT_HTTP_HOST, Consul.DEFAULT_HTTP_PORT));
+
+            assertThat(factory.build()).isNotNull();
+        }
     }
 
     @Test
-    void shouldSetSocketPath() {
-        var consulFactory = new ConsulFactory();
-        consulFactory.setSocketPath("/tmp/consul.sock");
-        assertThat(consulFactory.getSocketPath()).isEqualTo("/tmp/consul.sock");
-    }
-
-    @Test
-    void shouldBuildConsulInstanceViaSocketPath() {
-        var consulFactory = new ConsulFactory();
-        consulFactory.setServicePing(false);
-        consulFactory.setSocketPath("/tmp/consul.sock");
-
-        var consul = consulFactory.build();
-        assertThat(consul).isNotNull();
-    }
-
-    @Test
-    void shouldThrowIllegalStateException_WhenBothSocketPathAndNonDefaultEndpointConfigured() {
-        var consulFactory = new ConsulFactory();
-        consulFactory.setSocketPath("/tmp/consul.sock");
-        consulFactory.setEndpoint(com.google.common.net.HostAndPort.fromParts("consul.example.com", 8500));
-
-        assertThatIllegalStateException().isThrownBy(consulFactory::build)
-            .withMessageContaining("socketPath")
-            .withMessageContaining("endpoint");
-    }
-
-    @Test
-    void socketPath_ShouldAffectEquality() {
+    void unixDomainSocketPath_ShouldAffectEquality() {
         var factory1 = createFullyPopulatedConsulFactory();
         var factory2 = createFullyPopulatedConsulFactory();
-        factory2.setSocketPath("/tmp/consul.sock");
+        factory2.setUnixDomainSocketPath("/tmp/consul.sock");
         assertThat(factory1).isNotEqualTo(factory2);
     }
 
     @Test
-    void socketPath_ShouldAffectHashCode() {
+    void unixDomainSocketPath_ShouldAffectHashCode() {
         var factory1 = createFullyPopulatedConsulFactory();
         var factory2 = createFullyPopulatedConsulFactory();
-        factory2.setSocketPath("/tmp/consul.sock");
+        factory2.setUnixDomainSocketPath("/tmp/consul.sock");
         assertThat(factory1.hashCode()).isNotEqualTo(factory2.hashCode());
     }
 
@@ -260,6 +262,35 @@ class ConsulFactoryTest {
 
             var violations = VALIDATOR.validateProperty(factory, "deregisterInterval");
             assertThat(violations).hasSize(1);
+        }
+
+        @Test
+        void shouldPassValidation_WhenSocketPathIsNotConfigured() {
+            // unixDomainSocketPath is null by default; any endpoint is valid
+            factory.setEndpoint(HostAndPort.fromParts("consul.example.com", 8500));
+
+            var violations = VALIDATOR.validate(factory);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void shouldAllowSocketPath_WhenEndpointIsDefault() {
+            factory.setUnixDomainSocketPath("/tmp/consul.sock");
+
+            var violations = VALIDATOR.validate(factory);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void shouldRejectSocketPath_WhenNonDefaultEndpointIsAlsoConfigured() {
+            factory.setUnixDomainSocketPath("/tmp/consul.sock");
+            factory.setEndpoint(HostAndPort.fromParts("consul.example.com", 8500));
+
+            var violations = VALIDATOR.validate(factory);
+            assertThat(violations).hasSize(1);
+            assertThat(violations.iterator().next().getMessage())
+                .contains("unixDomainSocketPath")
+                .contains("endpoint");
         }
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/consul/ConsulFactoryTest.java
@@ -265,6 +265,26 @@ class ConsulFactoryTest {
         }
 
         @Test
+        void shouldPassValidation_WhenUnixDomainSocketPathIsNull() {
+            assertThat(factory.getUnixDomainSocketPath()).isNull();
+
+            var violations = VALIDATOR.validate(factory);
+            assertThat(violations).isEmpty();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "\t"})
+        void shouldRejectBlankUnixDomainSocketPath(String blank) {
+            factory.setUnixDomainSocketPath(blank);
+
+            var violations = VALIDATOR.validate(factory);
+            assertThat(violations).hasSize(1);
+            assertThat(violations.iterator().next().getMessage())
+                .contains("unixDomainSocketPath")
+                .contains("blank");
+        }
+
+        @Test
         void shouldPassValidation_WhenSocketPathIsNotConfigured() {
             // unixDomainSocketPath is null by default; any endpoint is valid
             factory.setEndpoint(HostAndPort.fromParts("consul.example.com", 8500));


### PR DESCRIPTION
Add unixDomainSocketPath to ConsulFactory and getConsulAgentUnixDomainSocketPath()
to ConsulBundle, allowing a Dropwizard service to connect to a local Consul
agent via a Unix domain socket instead of TCP.

ConsulFactory gains a nullable unixDomainSocketPath field
(YAML: consul.unixDomainSocketPath). When set, build() calls
withUnixDomainSocket(unixDomainSocketPath) instead of withHostAndPort(endpoint).
Configuring both unixDomainSocketPath and a non-default endpoint is rejected by
an @AssertTrue constraint during Dropwizard configuration parsing.
unixDomainSocketPath is included in hashCode and equals.

ConsulBundle gains getConsulAgentUnixDomainSocketPath() returning Optional<String>,
defaulting to empty. initialize() uses the socket path when present, otherwise
falls through to the existing host/port path. The @VisibleForTesting annotation
is removed from getConsulAgentHost(), getConsulAgentPort(), and
getConsulAclToken() since these are intentional extension points, not test seams.

junixsocket-core is declared as an optional dependency (version managed by
kiwi-bom 3.1.0+) and must be added explicitly by users who configure
unixDomainSocketPath.

Depends on consul-client 1.12.0, which adds Consul.Builder.withUnixDomainSocket()
and the UnixDomainSocketFactory that routes OkHttp connections through the socket.

Closes #306